### PR TITLE
UF-75 commitlint에서 머지 커밋과 UF- 형식 허용

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -25,14 +25,14 @@ module.exports = {
 
   // 무시할 패턴
   ignores: [
-    (message) => message.startsWith('Merge pull request'),
-    (message) => message.startsWith('Merge branch'),
-    (message) => message.includes('Merge remote-tracking branch'),
-    (message) => message.startsWith('UF-'),
-    (message) => message.startsWith('[UF-'),
-    (message) => /^UF-\d+/.test(message),
-    (message) => /^\[UF-\d+\]/.test(message),
-    (message) => message.startsWith('Revert'),
-    (message) => message.startsWith('Initial commit'),
+    (message) => message.startsWith('Merge pull request'), // PR 머지
+    (message) => message.startsWith('Merge branch'), // 브랜치 머지
+    (message) => message.includes('Merge remote-tracking branch'), // 원격 브랜치 머지
+    (message) => message.startsWith('UF-'), // UF-123: 제목
+    (message) => message.startsWith('[UF-'), // [UF-123] 제목
+    (message) => /^UF-\d+/.test(message), // UF-숫자
+    (message) => /^\[UF-\d+\]/.test(message), // [UF-숫자]
+    (message) => message.startsWith('Revert'), // 리버트 커밋
+    (message) => message.startsWith('Initial commit'), // 초기 커밋
   ],
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,22 +1,38 @@
 module.exports = {
-  extends: ["@commitlint/config-conventional"],
+  extends: ['@commitlint/config-conventional'],
   rules: {
-    "type-enum": [
+    'type-enum': [
       2,
-      "always",
+      'always',
       [
-        "feat",
-        "fix",
-        "refactor",
-        "docs",
-        "test",
-        "chore",
-        "style",
-        "delete",
-        "move",
-        "update",
+        'feat',
+        'fix',
+        'refactor',
+        'docs',
+        'test',
+        'chore',
+        'style',
+        'delete',
+        'move',
+        'update',
+        'ci', // CI 관련
+        'build', // 빌드 관련
       ],
     ],
-    "subject-case": [0], // 한글 허용
+    'subject-case': [0], // 한글 허용
+    'header-max-length': [0], // 길이 제한 해제
   },
+
+  // 무시할 패턴
+  ignores: [
+    (message) => message.startsWith('Merge pull request'),
+    (message) => message.startsWith('Merge branch'),
+    (message) => message.includes('Merge remote-tracking branch'),
+    (message) => message.startsWith('UF-'),
+    (message) => message.startsWith('[UF-'),
+    (message) => /^UF-\d+/.test(message),
+    (message) => /^\[UF-\d+\]/.test(message),
+    (message) => message.startsWith('Revert'),
+    (message) => message.startsWith('Initial commit'),
+  ],
 };


### PR DESCRIPTION
### **User description**
### #️⃣ 연관된 이슈

> close: #42 

### 🔎 작업 내용

- [x] commitlint에서 머지 커밋과 UF- 형식 허용

### 📸 스크린샷 (선택)

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


___

### **PR Type**
enhancement


___

### **Description**
- commitlint 설정 업데이트

- 머지 커밋 및 UF- 형식 허용

- 커밋 메시지 패턴 무시 규칙 추가


___

### **Changes diagram**

```mermaid
flowchart LR
  A["commitlint 설정"] -- "업데이트" --> B["머지 커밋 허용"]
  A -- "업데이트" --> C["UF- 형식 허용"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commitlint.config.js</strong><dd><code>commitlint 규칙 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

commitlint.config.js

- commitlint 규칙 업데이트
- 머지 커밋 패턴 무시 추가
- UF- 형식 커밋 메시지 허용


</details>


  </td>
  <td><a href="https://github.com/Ureca-Final-Project-Team1/UFO-Fi-FE/pull/43/files#diff-2b1ae4316086c0ebb213227790133a792300e1cef03b0afc067b23d3399ea5ca">+30/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>