### PR TITLE
UF-135 프로그래스 컴포넌트 텍스트 위치, 색상, 아이콘 추가

### DIFF
--- a/src/shared/ui/Icons/Icons.types.ts
+++ b/src/shared/ui/Icons/Icons.types.ts
@@ -49,7 +49,8 @@ export type LucideIconType =
   | 'BellRing'
   | 'AlertCircle' // 에러용
   | 'ImageOff' // 이미지 에러용
-  | 'Loader2'; // 로딩용
+  | 'Loader2' // 로딩용
+  | 'Signal'; // 신호 아이콘 추가
 
 // 커스텀 아이콘 타입
 export type CustomIconType =

--- a/src/shared/ui/Progress/Progress.tsx
+++ b/src/shared/ui/Progress/Progress.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as ProgressPrimitive from '@radix-ui/react-progress';
+import { Signal } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -22,8 +23,12 @@ export function Progress({
     <div className={cn('space-y-2', className)}>
       {/* 현재 사용 용량 표시 */}
       {showCurrentUsage && (
-        <div className="flex justify-center">
-          <span className="text-sm font-medium text-gray-700">{usedStorage}GB</span>
+        <div className="flex items-center gap-2">
+          {/* 신호 아이콘 */}
+          <Signal className="w-5 h-5 text-green-500" />
+
+          {/* 사용량 텍스트 (chart-4 색상 적용) */}
+          <span className="text-[28px] font-bold leading-none text-chart-4">{usedStorage}GB</span>
         </div>
       )}
 

--- a/src/shared/ui/Progress/Progress.tsx
+++ b/src/shared/ui/Progress/Progress.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import * as ProgressPrimitive from '@radix-ui/react-progress';
-import { Signal } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { Icon } from '@/shared/ui/Icons';
 
 import { ProgressProps } from './Progress.types';
 import { progressVariants, progressIndicatorVariants } from './progressVariants';
@@ -25,7 +25,7 @@ export function Progress({
       {showCurrentUsage && (
         <div className="flex items-center gap-2">
           {/* 신호 아이콘 */}
-          <Signal className="w-5 h-5 text-green-500" />
+          <Icon name="Signal" size={20} className="text-status-positive" />
 
           {/* 사용량 텍스트 (chart-4 색상 적용) */}
           <span className="text-[28px] font-bold leading-none text-chart-4">{usedStorage}GB</span>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -468,4 +468,8 @@
   .text-chart-4 {
     color: var(--chart-4);
   }
+
+  .text-status-positive {
+    color: var(--color-status-positive) !important;
+  }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -159,7 +159,7 @@
 
   --color-accent-red: #f5506c;
 
-  --color-button-border: #31D7F3;
+  --color-button-border: #31d7f3;
 
   /* 탐색 버튼 색상 */
   --color-exploration-gradient-from: #266dfd;
@@ -463,5 +463,9 @@
   .exploration-button:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .text-chart-4 {
+    color: var(--chart-4);
   }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #109 

### 🔎 작업 내용

- [x] 마이페이지에 들어갈 프로그래스 바 부분을 위해 컴포넌트의 텍스트 배치 변경
- [x] 스토리북 확인

### 📸 스크린샷 (선택)
<img width="335" height="94" alt="image" src="https://github.com/user-attachments/assets/43141b85-8de5-47d8-abe8-57d90a716b93" />
<img width="703" height="452" alt="image" src="https://github.com/user-attachments/assets/ffc7c8fd-748c-42a0-86be-ba7de15dbd99" />

### 📢 전달사항
global.css에 있는 --chart-4를 @layer utilities에서 .text-chart-4로 선언하여 사용 중 입니다.
<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?
