### PR TITLE
UF-180 결제 간편 비밀번호 페이지,컴포넌트 추가

### DIFF
--- a/src/app/payment/password/page.tsx
+++ b/src/app/payment/password/page.tsx
@@ -3,45 +3,84 @@
 import { useState } from 'react';
 
 import PasswordPad from '@/features/payment/components/PasswordPad';
+import { PaymentCancellationModal } from '@/features/payment/components/PaymentCancellationModal';
 import { Title } from '@/shared/ui';
 
 export default function PaymentPasswordPage() {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [password, setPassword] = useState('');
+  const [step, setStep] = useState<'register' | 'confirm'>('register');
+  const [registeredPw, setRegisteredPw] = useState('');
+  const [error, setError] = useState('');
+  const [errorCount, setErrorCount] = useState(0);
+  const [showCancelModal, setShowCancelModal] = useState(false);
 
-  const handleComplete = (pw: string) => {
-    setPassword(pw);
-    // TODO: 비밀번호 등록/검증 로직 추가
-    alert(`입력된 비밀번호: ${pw}`);
+  // 등록 단계: 비밀번호 저장 후 확인 단계로 이동
+  const handleRegisterComplete = (pw: string) => {
+    setRegisteredPw(pw);
+    setStep('confirm');
+    setError('');
+    setErrorCount(0);
   };
 
-  const handleDelete = () => {
-    // TODO: 필요시 삭제 이벤트 처리
+  // 확인 단계: 입력값이 등록된 비밀번호와 일치하는지 확인
+  const handleConfirmComplete = (pw: string) => {
+    if (pw === registeredPw) {
+      setError('');
+      alert('비밀번호가 정상적으로 등록되었습니다!');
+      // TODO: 실제 등록 처리 및 페이지 이동
+    } else {
+      setStep('confirm');
+      setError('비밀번호가 일치하지 않습니다. 다시 입력해주세요.');
+      setErrorCount((c) => c + 1);
+    }
   };
 
-  const handleClear = () => {
-    setPassword('');
-  };
+  const handleDelete = () => {};
+  const handleClear = () => {};
 
   return (
-    <div className="w-full min-h-screen text-white px-4 py-6 space-y-8">
-      <Title title="간편비밀번호 등록" iconVariant="back" />
+    <div className="w-full  text-white px-4 py-6 space-y-8">
+      <Title
+        title="간편비밀번호 등록"
+        iconVariant="back"
+        onClick={() => setShowCancelModal(true)}
+      />
       <div className="flex-1 flex items-center justify-center">
         <PasswordPad
-          onComplete={handleComplete}
+          key={step === 'register' ? 'register' : `confirm-${errorCount}`}
+          onComplete={step === 'register' ? handleRegisterComplete : handleConfirmComplete}
           onDelete={handleDelete}
           onClear={handleClear}
           maxLength={6}
-          title="간편비밀번호 6자리를 등록해주세요"
+          title={
+            step === 'register'
+              ? '간편비밀번호 6자리를 등록해주세요'
+              : '비밀번호를 한 번 더 입력해주세요'
+          }
           subtitle={
-            <>
-              결제 시 사용할 비밀번호입니다.
-              <br />
-              (최초 1회 등록)
-            </>
+            step === 'register' ? (
+              <>
+                결제 시 사용할 비밀번호입니다.
+                <br />
+                (최초 1회 등록)
+              </>
+            ) : (
+              '동일한 비밀번호를 입력해 주세요.'
+            )
           }
         />
       </div>
+      {error && <div className="text-center text-red-400 font-bold">{error}</div>}
+      {showCancelModal && (
+        <PaymentCancellationModal
+          isOpen={showCancelModal}
+          onClose={() => setShowCancelModal(false)}
+          onCancel={() => setShowCancelModal(false)}
+          onConfirm={() => {
+            // TODO: 나가기 로직 추가
+            setShowCancelModal(false);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/payment/password/page.tsx
+++ b/src/app/payment/password/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+
+import PasswordPad from '@/features/payment/components/PasswordPad';
+import { Title } from '@/shared/ui';
+
+export default function PaymentPasswordPage() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [password, setPassword] = useState('');
+
+  const handleComplete = (pw: string) => {
+    setPassword(pw);
+    // TODO: 비밀번호 등록/검증 로직 추가
+    alert(`입력된 비밀번호: ${pw}`);
+  };
+
+  const handleDelete = () => {
+    // TODO: 필요시 삭제 이벤트 처리
+  };
+
+  const handleClear = () => {
+    setPassword('');
+  };
+
+  return (
+    <div className="w-full min-h-screen text-white px-4 py-6 space-y-8">
+      <Title title="간편비밀번호 등록" iconVariant="back" />
+      <div className="flex-1 flex items-center justify-center">
+        <PasswordPad
+          onComplete={handleComplete}
+          onDelete={handleDelete}
+          onClear={handleClear}
+          maxLength={6}
+          title="간편비밀번호 6자리를 등록해주세요"
+          subtitle={
+            <>
+              결제 시 사용할 비밀번호입니다.
+              <br />
+              (최초 1회 등록)
+            </>
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/payment/components/NumberButton.tsx
+++ b/src/features/payment/components/NumberButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface NumberButtonProps {
+  number: number;
+  onClick: (number: number) => void;
+  disabled?: boolean;
+}
+
+export default function NumberButton({ number, onClick, disabled = false }: NumberButtonProps) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onClick(number)}
+      className={`w-16 h-16 rounded-full text-white text-2xl font-bold flex items-center justify-center
+        bg-transparent hover:bg-gray-700 transition-colors border border-gray-600
+        ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+    >
+      {number}
+    </button>
+  );
+}

--- a/src/features/payment/components/PasswordInput.tsx
+++ b/src/features/payment/components/PasswordInput.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface PasswordInputProps {
+  value: string;
+  maxLength: number;
+  showDots?: boolean;
+}
+
+export default function PasswordInput({ value, maxLength, showDots = true }: PasswordInputProps) {
+  return (
+    <div className="flex justify-center gap-4">
+      {Array.from({ length: maxLength }).map((_, idx) => (
+        <span
+          key={idx}
+          className={`w-5 h-5 rounded-full border-2 transition-colors ${
+            idx < value.length ? 'bg-white border-white' : 'bg-transparent border-white/40'
+          }`}
+        >
+          {!showDots && idx < value.length ? value[idx] : null}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/features/payment/components/PasswordPad.tsx
+++ b/src/features/payment/components/PasswordPad.tsx
@@ -1,4 +1,3 @@
-// src/features/payment/components/PasswordPad.tsx
 'use client';
 
 import { useState, useCallback } from 'react';
@@ -8,6 +7,8 @@ import { Icon } from '@/shared/ui';
 import NumberButton from './NumberButton';
 import PasswordInput from './PasswordInput';
 import { PasswordPadProps } from '../types/PasswordPad.types';
+
+const NUMBER_PAD = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
 
 export default function PasswordPad({
   onComplete,
@@ -23,10 +24,8 @@ export default function PasswordPad({
   const handleNumberClick = useCallback(
     (number: number) => {
       if (disabled || password.length >= maxLength) return;
-
       const newPassword = password + number.toString();
       setPassword(newPassword);
-
       if (newPassword.length === maxLength) {
         onComplete(newPassword);
       }
@@ -36,7 +35,6 @@ export default function PasswordPad({
 
   const handleDelete = useCallback(() => {
     if (disabled) return;
-
     const newPassword = password.slice(0, -1);
     setPassword(newPassword);
     onDelete();
@@ -44,41 +42,53 @@ export default function PasswordPad({
 
   const handleClear = useCallback(() => {
     if (disabled) return;
-
     setPassword('');
     onClear();
   }, [onClear, disabled]);
 
-  // 숫자 배열 (1~9만)
-  const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-
   return (
-    <div className="flex flex-col items-center w-full max-w-md mx-auto p-6 rounded-2xl">
+    <div
+      className="flex flex-col items-center w-full max-w-md mx-auto rounded-2xl"
+      aria-label="비밀번호 입력 패드"
+    >
       {/* 헤더 */}
-      <div className="mb-8 text-center">
+      <div className="mb-5 text-center">
         <h2 className="text-white text-xl font-bold mb-2">{title}</h2>
         <p className="text-gray-400 text-sm">{subtitle}</p>
       </div>
 
+      {/* 상태 메시지 */}
+      <div className="text-center mb-2">
+        <p className="text-gray-500 text-xs" aria-live="polite">
+          {password.length}/{maxLength}
+        </p>
+      </div>
+
       {/* 비밀번호 입력 표시 */}
       <div className="mb-8">
-        <PasswordInput value={password} maxLength={maxLength} showDots={true} />
+        <PasswordInput
+          value={password}
+          maxLength={maxLength}
+          showDots
+          aria-label="비밀번호 입력란"
+        />
       </div>
 
       {/* 숫자 키패드 */}
-      <div className="grid grid-cols-3 gap-5 mb-6 mt-10">
-        {numbers.map((number) => (
+      <div className="grid grid-cols-3 gap-5 mb-6 mt-5">
+        {NUMBER_PAD.slice(0, 9).map((number) => (
           <NumberButton
             key={number}
             number={number}
             onClick={handleNumberClick}
             disabled={disabled}
+            aria-label={`${number} 입력`}
           />
         ))}
       </div>
 
       {/* 하단 행: 전체삭제, 0, 하나삭제 */}
-      <div className="grid grid-cols-3 gap-5 mb-6">
+      <div className="grid grid-cols-3 gap-5">
         {/* 전체삭제 */}
         <div className="flex justify-center">
           <button
@@ -86,13 +96,19 @@ export default function PasswordPad({
             onClick={handleClear}
             disabled={disabled}
             className="w-16 h-16 rounded-full text-white text-sm font-bold flex items-center justify-center"
+            aria-label="전체 삭제"
           >
             전체삭제
           </button>
         </div>
 
         {/* 0 */}
-        <NumberButton number={0} onClick={handleNumberClick} disabled={disabled} />
+        <NumberButton
+          number={0}
+          onClick={handleNumberClick}
+          disabled={disabled}
+          aria-label="0 입력"
+        />
 
         {/* ← 삭제 */}
         <div className="flex justify-center">
@@ -101,17 +117,11 @@ export default function PasswordPad({
             onClick={handleDelete}
             disabled={disabled || password.length === 0}
             className="w-16 h-16 rounded-full flex items-center justify-center"
+            aria-label="한 글자 삭제"
           >
             <Icon name="ChevronLeft" size={24} className="text-white" />
           </button>
         </div>
-      </div>
-
-      {/* 상태 메시지 */}
-      <div className="text-center">
-        <p className="text-gray-500 text-xs">
-          {password.length}/{maxLength}
-        </p>
       </div>
     </div>
   );

--- a/src/features/payment/components/PasswordPad.tsx
+++ b/src/features/payment/components/PasswordPad.tsx
@@ -1,0 +1,118 @@
+// src/features/payment/components/PasswordPad.tsx
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import { Icon } from '@/shared/ui';
+
+import NumberButton from './NumberButton';
+import PasswordInput from './PasswordInput';
+import { PasswordPadProps } from '../types/PasswordPad.types';
+
+export default function PasswordPad({
+  onComplete,
+  onDelete,
+  onClear,
+  maxLength = 6,
+  title = '결제 비밀번호',
+  subtitle = '비밀번호를 입력해주세요',
+  disabled = false,
+}: PasswordPadProps) {
+  const [password, setPassword] = useState('');
+
+  const handleNumberClick = useCallback(
+    (number: number) => {
+      if (disabled || password.length >= maxLength) return;
+
+      const newPassword = password + number.toString();
+      setPassword(newPassword);
+
+      if (newPassword.length === maxLength) {
+        onComplete(newPassword);
+      }
+    },
+    [password, maxLength, onComplete, disabled],
+  );
+
+  const handleDelete = useCallback(() => {
+    if (disabled) return;
+
+    const newPassword = password.slice(0, -1);
+    setPassword(newPassword);
+    onDelete();
+  }, [password, onDelete, disabled]);
+
+  const handleClear = useCallback(() => {
+    if (disabled) return;
+
+    setPassword('');
+    onClear();
+  }, [onClear, disabled]);
+
+  // 숫자 배열 (1~9만)
+  const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+  return (
+    <div className="flex flex-col items-center w-full max-w-md mx-auto p-6 rounded-2xl">
+      {/* 헤더 */}
+      <div className="mb-8 text-center">
+        <h2 className="text-white text-xl font-bold mb-2">{title}</h2>
+        <p className="text-gray-400 text-sm">{subtitle}</p>
+      </div>
+
+      {/* 비밀번호 입력 표시 */}
+      <div className="mb-8">
+        <PasswordInput value={password} maxLength={maxLength} showDots={true} />
+      </div>
+
+      {/* 숫자 키패드 */}
+      <div className="grid grid-cols-3 gap-5 mb-6 mt-10">
+        {numbers.map((number) => (
+          <NumberButton
+            key={number}
+            number={number}
+            onClick={handleNumberClick}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+
+      {/* 하단 행: 전체삭제, 0, 하나삭제 */}
+      <div className="grid grid-cols-3 gap-5 mb-6">
+        {/* 전체삭제 */}
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={handleClear}
+            disabled={disabled}
+            className="w-16 h-16 rounded-full text-white text-sm font-bold flex items-center justify-center"
+          >
+            전체삭제
+          </button>
+        </div>
+
+        {/* 0 */}
+        <NumberButton number={0} onClick={handleNumberClick} disabled={disabled} />
+
+        {/* ← 삭제 */}
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={disabled || password.length === 0}
+            className="w-16 h-16 rounded-full flex items-center justify-center"
+          >
+            <Icon name="ChevronLeft" size={24} className="text-white" />
+          </button>
+        </div>
+      </div>
+
+      {/* 상태 메시지 */}
+      <div className="text-center">
+        <p className="text-gray-500 text-xs">
+          {password.length}/{maxLength}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/payment/types/PasswordPad.types.ts
+++ b/src/features/payment/types/PasswordPad.types.ts
@@ -1,0 +1,21 @@
+export interface PasswordPadProps {
+  onComplete: (password: string) => void;
+  onDelete: () => void;
+  onClear: () => void;
+  maxLength?: number;
+  title?: string;
+  subtitle?: React.ReactNode;
+  disabled?: boolean;
+}
+
+export interface NumberButtonProps {
+  number: number;
+  onClick: (number: number) => void;
+  disabled?: boolean;
+}
+
+export interface PasswordInputProps {
+  value: string;
+  maxLength: number;
+  showDots?: boolean;
+}

--- a/src/provider/BackgroundProvider.tsx
+++ b/src/provider/BackgroundProvider.tsx
@@ -12,6 +12,8 @@ interface BackgroundProviderProps {
 export function BackgroundProvider({ children }: BackgroundProviderProps) {
   const pathname = usePathname();
 
+  const isPasswordPage = pathname.includes('password');
+
   const backgroundImageUrl = (() => {
     if (
       pathname.startsWith('/login') ||
@@ -25,14 +27,26 @@ export function BackgroundProvider({ children }: BackgroundProviderProps) {
       return IMAGE_PATHS.BG_ONBOARDING;
     }
 
+    if (isPasswordPage) {
+      return '';
+    }
+
     return IMAGE_PATHS.BG_BASIC;
   })();
 
+  const containerClass = [
+    'w-full min-h-full flex flex-col items-center justify-between sm:px-10.5 px-4 text-white',
+    isPasswordPage ? '' : 'bg-cover bg-no-repeat bg-top',
+  ].join(' ');
+
+  const containerStyle = isPasswordPage
+    ? { backgroundColor: 'var(--color-password-bg)' }
+    : backgroundImageUrl
+      ? { backgroundImage: `url(${backgroundImageUrl})` }
+      : {};
+
   return (
-    <div
-      className="w-full min-h-full bg-cover bg-no-repeat bg-top flex flex-col items-center justify-between sm:px-10.5 px-4 text-white"
-      style={{ backgroundImage: `url(${backgroundImageUrl})` }}
-    >
+    <div className={containerClass} style={containerStyle}>
       {children}
     </div>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -203,6 +203,8 @@
   --width-mobile-min: 375px;
   --width-mobile-max: 620px;
   --color-border-zet: #1379c8;
+
+  --color-password-bg: #070d24;
 }
 
 @layer base {


### PR DESCRIPTION
### **User description**
### #️⃣ 연관된 이슈

> close: #151 

### 🔎 작업 내용

- [x] 결제 정보 등록에 들어가는 간편 비밀번호 등록 페이지 추가
- [x] 키패드를 컴포넌트로 분리하여 추후 결제 페이지에서 재사용하기

### 📸 스크린샷 (선택)

<img width="677" height="912" alt="image" src="https://github.com/user-attachments/assets/2acf2586-2a4c-4be7-9a82-a86fc1269e84" />


비밀번호 1차 입력 중
<img width="655" height="290" alt="image" src="https://github.com/user-attachments/assets/a48723c1-aea0-4262-bae8-02911a2f3bd1" />

동일한 비밀번호 다시 입력
<img width="660" height="272" alt="image" src="https://github.com/user-attachments/assets/3a784dad-6428-4b70-ac13-62ce485fc531" />

일치하지 않는 경우
<img width="672" height="771" alt="image" src="https://github.com/user-attachments/assets/0c5ea0cc-dcec-42c2-a470-220cea2421b1" />

1차 2차 일치하는 경우
<img width="493" height="172" alt="image" src="https://github.com/user-attachments/assets/a9f54561-4a90-43c2-b899-47d2a226409d" />
현재는 alert 처리

### 📢 전달사항
space-y-8 때문에 하단 margin 발생하는데 어떻게 처리할지?
<img width="1368" height="910" alt="image" src="https://github.com/user-attachments/assets/62ed9415-6bbc-4f18-b9f4-5eeab3558b52" />

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [ ] 관련 이슈를 등록하고 연결했나요?
- [ ] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [ ] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


___

### **PR Type**
Enhancement


___

### **Description**
- 간편 비밀번호 등록 페이지 추가

- 비밀번호 입력 패드 컴포넌트 구현

- 비밀번호 확인 로직 추가

- 배경 처리 로직 수정


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["간편 비밀번호 등록 페이지"] -- "비밀번호 입력" --> B["비밀번호 입력 패드"]
  B -- "비밀번호 확인" --> C["비밀번호 등록 완료"]
  C -- "비밀번호 불일치" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___

