### PR TITLE
UF-128 부모 크기에 맞게 슬라이더 가변하도록 구현

### DIFF
--- a/src/shared/ui/Slider/DataSlider.tsx
+++ b/src/shared/ui/Slider/DataSlider.tsx
@@ -18,12 +18,12 @@ export function DataSlider({
   const steps = max;
 
   return (
-    <div className="relative w-full max-w-md px-4">
+    <div className="relative w-full px-4">
       {/* 중앙 값 라벨 */}
       {showMiddleLabels && (
         <div className="text-center text-cyan-300 font-bold text-lg mb-2">{value[0]}GB</div>
       )}
-      <div className="relative w-full max-w-[320px] mx-auto">
+      <div className="relative w-full mx-auto">
         {/* 눈금선 + 숫자 (min/max label은 하단에서만 표시) */}
         {showTicks && (
           <div className="absolute left-0 right-0 flex justify-between px-[2px] z-10">


### PR DESCRIPTION
### **User description**
### #️⃣ 연관된 이슈

> close: #100 

### 🔎 작업 내용

- [x] DataSlider 컴포넌트에서 max-w-md, max-w-[320px] 클래스를 제거하여 슬라이더가 부모의 100% width를 사용하도록 수정
- [x] 코드 전체적으로 슬라이더 width 관련 추가 수정이 필요한 부분이 없는지 점검

### 📸 스크린샷 (선택)
<img width="622" height="857" alt="image" src="https://github.com/user-attachments/assets/b258a5c4-ff58-48aa-8ff7-eef68374174a" />

### 📢 전달사항
- 이제 슬라이더는 별도의 max-width 제한 없이 부모 컨테이너의 가로 길이에 맞게 표시됩니다.
- 추가로 좌우 패딩(px-4)까지 완전히 제거하고 싶으면 말씀해 주세요.

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


___

### **PR Type**
enhancement


___

### **Description**
- 슬라이더 컴포넌트의 가로 길이 수정

- 부모 크기에 맞춰 100% width 사용

- max-width 제한 제거


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["슬라이더 컴포넌트"] -- "가로 길이 수정" --> B["부모 크기에 맞춤"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataSlider.tsx</strong><dd><code>슬라이더 컴포넌트 가로 길이 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shared/ui/Slider/DataSlider.tsx

- max-w-md, max-w-[320px] 클래스 제거
- 슬라이더가 부모의 100% width 사용


</details>


  </td>
  <td><a href="https://github.com/Ureca-Final-Project-Team1/UFO-Fi-FE/pull/173/files#diff-e60acfc5a64664024183b475d71e1166ee16ae5600869bcfd1db348663f5d228">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

