### PR TITLE
UF-176 refactor title back navigation

### DIFF
--- a/src/app/blackhole/page.tsx
+++ b/src/app/blackhole/page.tsx
@@ -1,17 +1,14 @@
 'use client';
 
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 
 import { IMAGE_PATHS } from '@/constants/images';
 import { Title } from '@/shared/ui';
 
 export default function BlackholePage() {
-  const router = useRouter();
-
   return (
     <div className="flex flex-col items-center min-h-full relative w-full">
-      <Title title="홈" iconVariant="back" onClick={() => router.back()} className="mb-0" />
+      <Title title="홈" iconVariant="back" className="mb-0" />
       <div className="flex-1 flex flex-col items-center justify-center w-full">
         <p className="body-16-bold text-white-600 text-center mb-2">
           당신은 안드로메다로 들어갔습니다...<span className="ml-1">😢</span>

--- a/src/app/charge/page.tsx
+++ b/src/app/charge/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-
 import { IMAGE_PATHS } from '@/constants/images';
 import { PACKAGES } from '@/constants/packages';
 import { ZetChargePackageCard } from '@/features/charge/components/ZetChargePackageCard';
@@ -9,13 +7,11 @@ import { Icon, Title } from '@/shared';
 import '@/styles/globals.css';
 
 export default function ZetChargePage() {
-  const router = useRouter();
-
   return (
     <div className="relative min-h-full flex flex-col">
       <div className="px-4 pt-4">
         <div className="flex items-center justify-between mb-2">
-          <Title title="ZET 코인 충전소" iconVariant="back" onClick={() => router.back()} />
+          <Title title="ZET 코인 충전소" iconVariant="back" />
         </div>
         <div className="flex items-center justify-between mb-4">
           <p className="body-16-medium text-white m-0">외계 전파 코인을 구매하세요!</p>

--- a/src/app/mypage/follow/page.tsx
+++ b/src/app/mypage/follow/page.tsx
@@ -48,7 +48,7 @@ export default function Page() {
 
   return (
     <div className="min-h-screen w-full text-white">
-      <Title title="팔로우 목록" iconVariant="back" onClick={() => window.history.back()} />
+      <Title title="팔로우 목록" iconVariant="back" />
 
       <div className="mx-4 mb-6">
         <Tabs defaultValue="followers">

--- a/src/app/mypage/privacy/page.tsx
+++ b/src/app/mypage/privacy/page.tsx
@@ -3,23 +3,13 @@
 import React from 'react';
 
 import privacyRaw from '@/assets/terms/privacy.md?raw';
-import { Icon } from '@/shared';
+import { Title } from '@/shared';
 import { renderTermsWithHeadingsAndLinks } from '@/shared/utils/termsRenderer';
 
 export default function TermsPage() {
   return (
     <div>
-      <div className="relative w-full flex items-center py-4 px-4">
-        <button
-          type="button"
-          onClick={() => window.history.back()}
-          className="absolute left-4 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors"
-          aria-label="back 버튼"
-        >
-          <Icon name="ChevronLeft" size="md" color="white" className="w-6 h-6 text-white" />
-        </button>
-        <h1 className="body-20-bold text-white w-full text-center">개인정보 처리방침</h1>
-      </div>
+      <Title title="개인정보 처리방침" iconVariant="back" />
       <div className="text-white overflow-y-auto text-sm max-h-[80vh] p-2 rounded-lg flex flex-col gap-1 leading-relaxed hide-scrollbar">
         {renderTermsWithHeadingsAndLinks(privacyRaw)}
       </div>

--- a/src/app/mypage/service/page.tsx
+++ b/src/app/mypage/service/page.tsx
@@ -3,23 +3,13 @@
 import React from 'react';
 
 import serviceRaw from '@/assets/terms/service.md?raw';
-import { Icon } from '@/shared';
+import { Title } from '@/shared';
 import { renderTermsWithHeadingsAndLinks } from '@/shared/utils/termsRenderer';
 
 export default function TermsPage() {
   return (
     <div>
-      <div className="relative w-full flex items-center py-4 px-4">
-        <button
-          type="button"
-          onClick={() => window.history.back()}
-          className="absolute left-4 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors"
-          aria-label="back 버튼"
-        >
-          <Icon name="ChevronLeft" size="md" color="white" className="w-6 h-6 text-white" />
-        </button>
-        <h1 className="body-20-bold text-white w-full text-center">이용약관</h1>
-      </div>
+      <Title title="이용약관" iconVariant="back" />
       <div className="text-white overflow-y-auto text-sm max-h-[80vh] p-2 rounded-lg flex flex-col gap-1 leading-relaxed hide-scrollbar">
         {renderTermsWithHeadingsAndLinks(serviceRaw)}
       </div>

--- a/src/app/payment/password/page.tsx
+++ b/src/app/payment/password/page.tsx
@@ -39,11 +39,7 @@ export default function PaymentPasswordPage() {
 
   return (
     <div className="w-full  text-white px-4 py-6 space-y-8">
-      <Title
-        title="간편비밀번호 등록"
-        iconVariant="back"
-        onClick={() => setShowCancelModal(true)}
-      />
+      <Title title="비밀번호 입력" iconVariant="back" />
       <div className="flex-1 flex items-center justify-center">
         <PasswordPad
           key={step === 'register' ? 'register' : `confirm-${errorCount}`}

--- a/src/features/bulk/components/BulkResultContent.tsx
+++ b/src/features/bulk/components/BulkResultContent.tsx
@@ -175,7 +175,7 @@ export function BulkResultContent({ initialData }: BulkResultContentProps) {
 
   return (
     <div className="flex flex-col min-h-full w-full">
-      <Title title="매칭된 데이터" iconVariant="back" />
+      <Title title="매칭된 데이터" iconVariant="back" onClick={() => router.back()} />
       <div className="px-4">
         <BulkResultDisplay
           data={resultData}

--- a/src/features/bulk/components/BulkResultContent.tsx
+++ b/src/features/bulk/components/BulkResultContent.tsx
@@ -175,7 +175,7 @@ export function BulkResultContent({ initialData }: BulkResultContentProps) {
 
   return (
     <div className="flex flex-col min-h-full w-full">
-      <Title title="매칭된 데이터" iconVariant="back" onClick={() => router.back()} />
+      <Title title="매칭된 데이터" iconVariant="back" />
       <div className="px-4">
         <BulkResultDisplay
           data={resultData}

--- a/src/shared/ui/Title/Title.tsx
+++ b/src/shared/ui/Title/Title.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/navigation';
 import React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -25,8 +26,21 @@ export const Title: React.FC<TitleProps> = ({
   className,
   ...props
 }) => {
+  const router = useRouter();
   const iconName = getIconName(iconVariant);
   const hasIcon = iconName !== null;
+
+  // 아이콘 클릭 핸들러
+  const handleClick = React.useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>): void => {
+      if (onClick) {
+        onClick(e);
+      } else if (iconVariant === 'back') {
+        router.back();
+      }
+    },
+    [onClick, iconVariant, router],
+  );
 
   return (
     <div className={cn('relative w-full flex items-center py-4 px-4', className)} {...props}>
@@ -34,7 +48,7 @@ export const Title: React.FC<TitleProps> = ({
       {hasIcon && (
         <button
           type="button"
-          onClick={onClick}
+          onClick={handleClick}
           className="absolute left-4 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors"
           aria-label={`${iconVariant} 버튼`}
         >

--- a/src/shared/ui/Title/Title.tsx
+++ b/src/shared/ui/Title/Title.tsx
@@ -22,7 +22,7 @@ const getIconName = (variant: TitleIconVariant | undefined): IconType | null => 
 export const Title: React.FC<TitleProps> = ({
   title,
   iconVariant = 'none',
-  onClick,
+  onIconClick,
   className,
   ...props
 }) => {
@@ -33,13 +33,13 @@ export const Title: React.FC<TitleProps> = ({
   // 아이콘 클릭 핸들러
   const handleClick = React.useCallback(
     (e: React.MouseEvent<HTMLButtonElement>): void => {
-      if (onClick) {
-        onClick(e);
+      if (onIconClick) {
+        onIconClick(e);
       } else if (iconVariant === 'back') {
         router.back();
       }
     },
-    [onClick, iconVariant, router],
+    [onIconClick, iconVariant, router],
   );
 
   return (

--- a/src/shared/ui/Title/Title.types.ts
+++ b/src/shared/ui/Title/Title.types.ts
@@ -9,5 +9,5 @@ export interface TitleProps
     VariantProps<typeof titleVariants> {
   title: string;
   iconVariant?: TitleIconVariant;
-  onClick?: () => void;
+  onIconClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #148 

### 🔎 작업 내용

- [x] Title 컴포넌트에서 iconVariant='back'일 때 자동으로 router.back() 처리되도록 리팩토링
- [x]  리팩토링한 코드가 정상 작동하는지 mypage/service 에서 확인

### 📸 스크린샷 (선택)

### 📢 전달사항
- Title 컴포넌트만 사용하면 뒤로가기 및 타이틀이 자동 처리되어 코드가 더 깔끔해졌습니다.
- 추가로 타 페이지에서도 동일한 구조 적용을 권장합니다

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?
