### PR TITLE
UF-216 refactor blackhole page

### DIFF
--- a/src/app/blackhole/page.tsx
+++ b/src/app/blackhole/page.tsx
@@ -1,17 +1,24 @@
 'use client';
 
 import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
 
 import { IMAGE_PATHS } from '@/constants/images';
 import { Title } from '@/shared/ui';
 
 export default function BlackholePage() {
+  const searchParams = useSearchParams();
+  const mode = searchParams.get('mode') || 'self';
+
   return (
     <div className="flex flex-col items-center min-h-full relative w-full">
       <Title title="홈" iconVariant="back" className="mb-0" />
       <div className="flex flex-col items-center w-full mt-25">
         <p className="body-16-bold text-white-600 text-center mb-2">
-          당신은 안드로메다로 들어갔습니다...<span className="ml-1">😢</span>
+          {mode === 'self'
+            ? '당신은 안드로메다로 들어갔습니다...'
+            : '이 사용자는 안드로메다로 들어갔습니다...'}
+          <span className="ml-1">😢</span>
         </p>
         <Image src={IMAGE_PATHS['BLACKHOLE_REAL']} alt="Blackhole" width="390" height="390" />
       </div>

--- a/src/app/blackhole/page.tsx
+++ b/src/app/blackhole/page.tsx
@@ -9,7 +9,7 @@ export default function BlackholePage() {
   return (
     <div className="flex flex-col items-center min-h-full relative w-full">
       <Title title="홈" iconVariant="back" className="mb-0" />
-      <div className="flex-1 flex flex-col items-center justify-center w-full">
+      <div className="flex flex-col items-center w-full mt-25">
         <p className="body-16-bold text-white-600 text-center mb-2">
           당신은 안드로메다로 들어갔습니다...<span className="ml-1">😢</span>
         </p>

--- a/src/app/blackhole/page.tsx
+++ b/src/app/blackhole/page.tsx
@@ -2,11 +2,12 @@
 
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
 
 import { IMAGE_PATHS } from '@/constants/images';
 import { Title } from '@/shared/ui';
 
-export default function BlackholePage() {
+function BlackholePageInner() {
   const searchParams = useSearchParams();
   const mode = searchParams.get('mode') || 'self';
 
@@ -23,5 +24,13 @@ export default function BlackholePage() {
         <Image src={IMAGE_PATHS['BLACKHOLE_REAL']} alt="Blackhole" width={390} height={390} />
       </div>
     </div>
+  );
+}
+
+export default function BlackholePage() {
+  return (
+    <Suspense>
+      <BlackholePageInner />
+    </Suspense>
   );
 }

--- a/src/app/blackhole/page.tsx
+++ b/src/app/blackhole/page.tsx
@@ -11,16 +11,16 @@ export default function BlackholePage() {
   const mode = searchParams.get('mode') || 'self';
 
   return (
-    <div className="flex flex-col items-center min-h-full relative w-full">
+    <div className="flex flex-col items-center min-h-full w-full">
       <Title title="홈" iconVariant="back" className="mb-0" />
-      <div className="flex flex-col items-center w-full mt-25">
-        <p className="body-16-bold text-white-600 text-center mb-2">
+      <div className="flex flex-col items-center w-full flex-1 justify-center">
+        <p className="text-lg font-bold text-white text-center mb-2">
           {mode === 'self'
             ? '당신은 안드로메다로 들어갔습니다...'
             : '이 사용자는 안드로메다로 들어갔습니다...'}
           <span className="ml-1">😢</span>
         </p>
-        <Image src={IMAGE_PATHS['BLACKHOLE_REAL']} alt="Blackhole" width="390" height="390" />
+        <Image src={IMAGE_PATHS['BLACKHOLE_REAL']} alt="Blackhole" width={390} height={390} />
       </div>
     </div>
   );

--- a/src/provider/BackgroundProvider.tsx
+++ b/src/provider/BackgroundProvider.tsx
@@ -12,9 +12,7 @@ export function BackgroundProvider({ children }: BackgroundProviderProps) {
   const isNavigationHidden =
     pathname.startsWith('/login') ||
     pathname.startsWith('/onboarding') ||
-    pathname.startsWith('/signup') ||
-    pathname.startsWith('/blackhole');
-
+    pathname.startsWith('/signup');
   return (
     <div
       className={`


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #205 

### 🔎 작업 내용

- [x] 블랙홀 페이지에서 불필요한 마진(mt-25) 제거 및 스크롤 완전 차단
- [x] 내부 컨텐츠를 flex-1 justify-center로 세로 중앙 정렬하여 모든 화면에서 스크롤 없이 자연스럽게 배치
- [x] 이미지 크기, 위치 등 기존 디자인은 유지하면서 UX 개선
- [x] Tailwind 및 글로벌 레이아웃 가이드에 맞게 구조 최적화
- [x] 중복된 컴포넌트/구조 재정비
- [x] 쿼리 파라미터를 통한 화면 분

### 📸 스크린샷 (선택)
<img width="373" height="808" alt="image" src="https://github.com/user-attachments/assets/83266aea-afce-4b70-be84-b9bc9592a829" />
<img width="370" height="807" alt="image" src="https://github.com/user-attachments/assets/d296d110-3dbd-428f-835e-8d394edb1cf4" />

### 📢 전달사항

-블랙홀 페이지에서 더 이상 스크롤이 발생하지 않으며, 모든 컨텐츠가 한 화면에 자연스럽게 중앙 정렬됩니다.
-기존 마진/위치 문제로 인한 스크롤 이슈가 완전히 해결되었습니다.
- 쿼리 파라미터를 통해 정지된 사용자를 클릭했을 때, 내가 정지된 상황일때를 구분하였습니다.
## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL의 `mode` 쿼리 파라미터에 따라 블랙홀 페이지의 안내 문구가 달라집니다.

* **Style**
  * 블랙홀 페이지의 레이아웃과 텍스트 스타일이 개선되었습니다.

* **Bug Fixes**
  * 블랙홀 페이지 경로에서 내비게이션이 숨겨지지 않도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->