### PR TITLE
UF-223 마이페이지 내 정보 수정 UI 추가

### DIFF
--- a/src/app/mypage/edit-profile/page.tsx
+++ b/src/app/mypage/edit-profile/page.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { plansAPI } from '@/api';
+import {
+  Title,
+  Input,
+  Button,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/shared';
+
+interface RawPlan {
+  planId: number;
+  planName: string;
+  sellMobileDataCapacityGB: number;
+  mobileDataType: string;
+}
+
+export default function EditProfilePage() {
+  const [nickname, setNickname] = useState('');
+  const [carrier, setCarrier] = useState('');
+  const [plan, setPlan] = useState('');
+  const [plans, setPlans] = useState<
+    { label: string; value: string; maxData: number; networkType: string }[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [maxData, setMaxData] = useState<number | null>(null);
+  const [networkType, setNetworkType] = useState('');
+  const prevCarrier = useRef('');
+
+  // 통신사 변경 시 요금제 목록 fetch
+  useEffect(() => {
+    const fetchPlans = async () => {
+      if (!carrier) return;
+      setIsLoading(true);
+      setApiError(null);
+
+      try {
+        const response: RawPlan[] = await plansAPI.getByCarrier(carrier);
+        setPlans(
+          response.map((plan) => ({
+            label: plan.planName,
+            value: plan.planName,
+            maxData: plan.sellMobileDataCapacityGB,
+            networkType: plan.mobileDataType,
+          })),
+        );
+        setPlan('');
+        setMaxData(null);
+        setNetworkType('');
+        if (!response || response.length === 0) {
+          setApiError('해당 통신사의 요금제를 찾을 수 없습니다.');
+        }
+      } catch {
+        setApiError('요금제 조회에 실패했습니다.');
+        setPlans([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (carrier && carrier !== prevCarrier.current) {
+      fetchPlans();
+      prevCarrier.current = carrier;
+    }
+  }, [carrier]);
+
+  // 요금제 선택 시 정보 세팅
+  useEffect(() => {
+    if (!plan) {
+      setMaxData(null);
+      setNetworkType('');
+      return;
+    }
+    const selected = plans.find((p) => p.value === plan);
+    if (selected) {
+      setMaxData(selected.maxData);
+      setNetworkType(selected.networkType);
+    }
+  }, [plan, plans]);
+
+  const isNicknameValid = nickname.length > 0 && nickname.length <= 15;
+  const isCarrierSelected = !!carrier;
+  const isPlanSelected = !!plan;
+
+  const handleSave = () => {
+    if (!isNicknameValid || !isCarrierSelected || !isPlanSelected) return;
+    // TODO: 저장 API 호출
+    alert('수정한 정보가 저장되었습니다!');
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen w-full">
+      <Title title="프로필 수정" iconVariant="back" />
+      <div className="mx-4 mt-6 flex flex-col gap-8">
+        {/* 닉네임 수정 */}
+        <div>
+          <h1 className="mb-4 font-semibold text-lg">닉네임 수정</h1>
+          <Input
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            placeholder="변경할 닉네임을 입력해주세요."
+            variant="whiteBorder"
+            maxLength={15}
+            error={!isNicknameValid && nickname ? '닉네임은 1~15자 이내여야 합니다.' : undefined}
+          />
+        </div>
+
+        {/* 요금제 변경 */}
+        <div>
+          <h2 className="mb-4 font-semibold text-base">요금제 변경</h2>
+          <div className="mb-4">
+            <label className="block mb-2 text-sm font-medium text-white">통신사 정보</label>
+            <Select value={carrier} onValueChange={setCarrier}>
+              <SelectTrigger className="w-full bg-white text-black">
+                <SelectValue placeholder="통신사 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="KT">KT</SelectItem>
+                <SelectItem value="SKT">SKT</SelectItem>
+                <SelectItem value="LGU">LG U+</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <label className="block mb-2 text-sm font-medium text-white">요금제 선택</label>
+            <Select
+              value={plan}
+              onValueChange={setPlan}
+              disabled={!carrier || isLoading || !!apiError}
+            >
+              <SelectTrigger className="w-full bg-white text-black">
+                <SelectValue
+                  placeholder={
+                    !carrier
+                      ? '먼저 통신사를 선택해주세요'
+                      : isLoading
+                        ? '요금제 조회 중...'
+                        : apiError
+                          ? '요금제 조회 실패'
+                          : plans.length === 0
+                            ? '요금제가 없습니다'
+                            : '요금제 선택'
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {plans.map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {apiError && <p className="text-red-500 text-xs mt-2">{apiError}</p>}
+          </div>
+        </div>
+
+        {/* 정보 확인 */}
+        {carrier && plan && maxData !== null && networkType && (
+          <div className="flex flex-col gap-3 mt-4">
+            <hr className="border-t border-white w-full" />
+            <p className="text-start w-full text-white font-bold text-base mb-2">
+              다음 정보가 맞는지 확인해주세요.
+            </p>
+            <div className="flex items-center justify-between text-white">
+              <span>판매할 수 있는 최대 데이터</span>
+              <span className="font-semibold">{maxData}GB</span>
+            </div>
+            <div className="flex items-center justify-between text-white">
+              <span>네트워크 타입</span>
+              <span className="font-semibold">{networkType}</span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 하단 고정 버튼 */}
+      <div className="sticky bottom-0 bg-inherit pb-4 mt-auto">
+        <Button
+          className="w-full h-14 mt-6"
+          disabled={!isNicknameValid || !isCarrierSelected || !isPlanSelected}
+          onClick={handleSave}
+        >
+          수정한 정보 저장하기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/Input/Input.tsx
+++ b/src/shared/ui/Input/Input.tsx
@@ -20,6 +20,7 @@ const Input = React.forwardRef<HTMLInputElement, CustomInputProps>(
             'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
             'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
             className,
+            variant === 'whiteBorder' ? 'bg-white text-black placeholder:text-gray-400' : '',
           )}
           {...props}
         />


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #214 

### 🔎 작업 내용

- [x] 마이페이지에서 내정보 수정 버튼을 누르면 나오는 페이지 ui 추가
- [x] 기존 회원가입(signup)에서 사용하던 api를 그대로 적용하여 ui 구현 완료

### 📸 스크린샷 (선택)
<img width="611" height="913" alt="image" src="https://github.com/user-attachments/assets/db280a45-1258-4570-ae48-6e15ef6a593c" />

### 📢 전달사항
따로따로 닉네임임만 수정 하고 싶은 경우나, 닉네임변경 없이 요금제만 변경하고 싶은 경우 어떻게 할지?
기본값으로 유저의 원래 닉네임, 요금제를 띄울지?

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사용자가 닉네임과 휴대폰 요금제 정보를 수정할 수 있는 프로필 편집 페이지가 추가되었습니다.
  * 통신사 선택 시 해당 통신사의 요금제를 실시간으로 불러오고, 선택한 요금제에 따라 최대 데이터 용량과 네트워크 유형 정보를 확인할 수 있습니다.
  * 닉네임 입력란에 1~15자 길이 제한 및 실시간 유효성 검사가 적용됩니다.

* **Style**
  * 흰색 테두리(whiteBorder) 스타일의 입력창에 배경색, 글자색, 플레이스홀더 색상이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->