### PR TITLE
UF-233 마이페이지 trade 라우터 수정

### DIFF
--- a/src/api/services/notification/settings.ts
+++ b/src/api/services/notification/settings.ts
@@ -1,18 +1,14 @@
 import { apiRequest } from '@/api/client/axios';
 import type {
   NotificationSettings,
-  GetNotificationSettingsRequest,
   UpdateNotificationSettingRequest,
 } from '@/api/types/notification';
 
 export const notificationAPI = {
-  async getSettings(
-    params: GetNotificationSettingsRequest,
-  ): Promise<NotificationSettings | undefined> {
+  async getSettings(): Promise<NotificationSettings | undefined> {
     try {
       const response = await apiRequest.get<{ content: NotificationSettings }>(
         '/v1/mypage/notification-settings',
-        { params },
       );
       return response.data.content;
     } catch (error) {

--- a/src/api/types/notification.ts
+++ b/src/api/types/notification.ts
@@ -1,7 +1,3 @@
-export interface GetNotificationSettingsRequest {
-  userId: number;
-}
-
 export interface NotificationSettings {
   benefit: boolean;
   sell: boolean;
@@ -12,7 +8,6 @@ export interface NotificationSettings {
 }
 
 export interface UpdateNotificationSettingRequest {
-  userId: number;
-  type: keyof NotificationSettings;
+  type: 'BENEFIT' | 'SELL' | 'INTERESTED_POST' | 'REPORTED' | 'FOLLOWER_POST' | 'TRADE';
   enable: boolean;
 }

--- a/src/app/mypage/notification/page.tsx
+++ b/src/app/mypage/notification/page.tsx
@@ -30,8 +30,7 @@ const MypageNotificationPage = () => {
   useEffect(() => {
     const fetchNotificationSettings = async () => {
       try {
-        // TODO: 인증 도입 시 변경할 것
-        const response = await notificationAPI.getSettings({ userId: 1 });
+        const response = await notificationAPI.getSettings();
 
         if (!response) return;
 
@@ -57,11 +56,9 @@ const MypageNotificationPage = () => {
   const handleToggle = async (type: NotificationKey, value: boolean) => {
     const newNotificationState = { ...notificationState, [type]: value };
 
-    // TODO: 인증 도입 시 변경할 것
     await notificationAPI.updateSetting({
-      userId: 1,
-      type: 'sell',
-      enable: false,
+      type,
+      enable: value,
     });
 
     if (type === 'TRADE') {

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -56,16 +56,28 @@ export default function MyPage() {
 
       {/* 메뉴 */}
       <div className="grid grid-cols-3 gap-4 text-center text-sm mb-4">
-        <div className="hover:cursor-pointer" onClick={navigateToFollow}>
-          <Icon name="Heart" size={24} className="mx-auto text-white" />
+        <div className="group hover:cursor-pointer" onClick={navigateToFollow}>
+          <Icon
+            name="Heart"
+            size={24}
+            className="mx-auto transition-all duration-300 group-hover:scale-110 text-white"
+          />
           <p className="mt-2 caption-12-regular">팔로우 목록</p>
         </div>
-        <div>
-          <Icon name="Eye" size={24} className="mx-auto text-white" />
+        <div className="group hover:cursor-pointer">
+          <Icon
+            name="Eye"
+            size={24}
+            className="mx-auto transition-all duration-300 group-hover:scale-110 text-white"
+          />
           <p className="mt-2 caption-12-regular">최근 본 글</p>
         </div>
-        <div className="hover:cursor-pointer" onClick={navigateToNotification}>
-          <Icon name="Bell" size={24} className="mx-auto text-white" />
+        <div className="group hover:cursor-pointer" onClick={navigateToNotification}>
+          <Icon
+            name="Bell"
+            size={24}
+            className="mx-autotransition-all duration-300 group-hover:scale-110 text-white"
+          />
           <p className="mt-2 caption-12-regular">알림 설정</p>
         </div>
       </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -11,8 +11,8 @@ export default function MyPage() {
   const router = useRouter();
   const { data: mypageInfo, error, isLoading } = useMyInfo();
 
-  const navigateToSalesHistory = () => router.push('/mypage/sales');
-  const navigateToPurchaseHistory = () => router.push('/mypage/receipt');
+  const navigateToSalesHistory = () => router.push('/mypage/trade?tab=sell');
+  const navigateToPurchaseHistory = () => router.push('/mypage/trade?tab=purchase');
   const navigateToLogout = () => router.push('/logout');
   const navigateToTerms = () => router.push('/terms');
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -15,6 +15,8 @@ export default function MyPage() {
   const navigateToPurchaseHistory = () => router.push('/mypage/trade?tab=purchase');
   const navigateToLogout = () => router.push('/logout');
   const navigateToTerms = () => router.push('/terms');
+  const navigateToFollow = () => router.push('/mypage/follow');
+  const navigateToNotification = () => router.push('/mypage/notification');
 
   const transactionItems = [
     { label: '판매 내역', onClick: navigateToSalesHistory },
@@ -46,7 +48,7 @@ export default function MyPage() {
 
       {/* 메뉴 */}
       <div className="grid grid-cols-3 gap-4 text-center text-sm mb-4">
-        <div>
+        <div className="hover:cursor-pointer" onClick={navigateToFollow}>
           <Icon name="Heart" size={24} className="mx-auto text-white" />
           <p className="mt-2 caption-12-regular">팔로우 목록</p>
         </div>
@@ -54,7 +56,7 @@ export default function MyPage() {
           <Icon name="Eye" size={24} className="mx-auto text-white" />
           <p className="mt-2 caption-12-regular">최근 본 글</p>
         </div>
-        <div>
+        <div className="hover:cursor-pointer" onClick={navigateToNotification}>
           <Icon name="Bell" size={24} className="mx-auto text-white" />
           <p className="mt-2 caption-12-regular">알림 설정</p>
         </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -6,13 +6,21 @@ import MenuSection from '@/features/mypage/components/MenuSection';
 import SignalCard from '@/features/mypage/components/SignalCard';
 import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
 import { Icon } from '@/shared/ui/Icons';
+import { useTradeTabStore } from '@/stores/useTradeTabStore';
 
 export default function MyPage() {
   const router = useRouter();
   const { data: mypageInfo, error, isLoading } = useMyInfo();
+  const { setTab } = useTradeTabStore();
 
-  const navigateToSalesHistory = () => router.push('/mypage/trade?tab=sell');
-  const navigateToPurchaseHistory = () => router.push('/mypage/trade?tab=purchase');
+  const navigateToSalesHistory = () => {
+    setTab('sell');
+    router.push('/mypage/trade');
+  };
+  const navigateToPurchaseHistory = () => {
+    setTab('purchase');
+    router.push('/mypage/trade');
+  };
   const navigateToLogout = () => router.push('/logout');
   const navigateToTerms = () => router.push('/terms');
   const navigateToFollow = () => router.push('/mypage/follow');

--- a/src/app/mypage/trade/page.tsx
+++ b/src/app/mypage/trade/page.tsx
@@ -43,8 +43,7 @@ const convertToCardProps = (
   }));
 
 const MyTradeHistoryPage = () => {
-  const { tab } = useTradeTabStore();
-  const [activeTab, setActiveTab] = useState(tab);
+  const { tab, setTab } = useTradeTabStore();
   const { sellTrade, purchaseTrade, setSellTrade, setPurchaseTrade } = useTradeHistory();
 
   const contentRef = useRef<HTMLDivElement>(null);
@@ -58,12 +57,12 @@ const MyTradeHistoryPage = () => {
   useEffect(() => {
     const fetchHistory = async () => {
       try {
-        if (activeTab === 'sell' && !fetchedTabs.sell) {
+        if (tab === 'sell' && !fetchedTabs.sell) {
           const response = await sellHistory();
           setSellTrade(response ?? []);
           setFetchedTabs((prev) => ({ ...prev, sell: true }));
         }
-        if (activeTab === 'purchase' && !fetchedTabs.purchase) {
+        if (tab === 'purchase' && !fetchedTabs.purchase) {
           const response = await purchaseHistory();
           setPurchaseTrade(response ?? []);
           setFetchedTabs((prev) => ({ ...prev, purchase: true }));
@@ -74,10 +73,10 @@ const MyTradeHistoryPage = () => {
     };
 
     fetchHistory();
-  }, [activeTab, fetchedTabs, setSellTrade, setPurchaseTrade]);
+  }, [tab, fetchedTabs, setSellTrade, setPurchaseTrade]);
 
   const handleTabChange = (value: string) => {
-    setActiveTab(value as 'sell' | 'purchase');
+    setTab(value as 'sell' | 'purchase');
     requestAnimationFrame(() => {
       contentRef.current?.scrollTo(0, 0);
     });
@@ -120,13 +119,13 @@ const MyTradeHistoryPage = () => {
     <div className="flex flex-col justify-start items-center w-full h-[calc(100vh-112px)]">
       <Tabs
         defaultValue="sell"
-        value={activeTab}
+        value={tab}
         onValueChange={handleTabChange}
         className="w-full h-full"
       >
         <TabsList className="bg-transparent w-full py-6 sm:py-8">
           <TabsTrigger
-            className="flex body-20-bold items-center py-6 sm:py-8"
+            className="flex body-16-bold items-center py-6 sm:py-8"
             value="sell"
             variant="darkTab"
             size="full"
@@ -134,7 +133,7 @@ const MyTradeHistoryPage = () => {
             판매 내역
           </TabsTrigger>
           <TabsTrigger
-            className="flex body-20-bold items-center py-6 sm:py-8"
+            className="flex body-16-bold items-center py-6 sm:py-8"
             value="purchase"
             variant="darkTab"
             size="full"

--- a/src/app/mypage/trade/page.tsx
+++ b/src/app/mypage/trade/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 import '@/styles/globals.css';
 
@@ -40,7 +40,9 @@ const convertToCardProps = (
   }));
 
 const MyTradeHistoryPage = () => {
-  const [activeTab, setActiveTab] = useState<'sell' | 'purchase'>('sell');
+  const searchParams = useSearchParams();
+  const initialTab = (searchParams.get('tab') as 'sell' | 'purchase') ?? 'sell';
+  const [activeTab, setActiveTab] = useState<'sell' | 'purchase'>(initialTab);
   const { sellTrade, purchaseTrade, setSellTrade, setPurchaseTrade } = useTradeHistory();
 
   const contentRef = useRef<HTMLDivElement>(null);

--- a/src/app/mypage/trade/page.tsx
+++ b/src/app/mypage/trade/page.tsx
@@ -2,7 +2,7 @@
 
 export const dynamic = 'force-dynamic';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 import '@/styles/globals.css';
 
@@ -13,6 +13,7 @@ import { TradeHistoryCard, TradeHistoryCardProps } from '@/features/mypage/compo
 import { useTradeHistory } from '@/hooks/useTradeHistory';
 import { BadgeState } from '@/shared';
 import { Button, Label, Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui';
+import { useTradeTabStore } from '@/stores/useTradeTabStore';
 import { groupByDate } from '@/utils/groupByDate';
 
 type TradeCardItem = TradeHistoryCardProps & { createdAt: Date };
@@ -42,9 +43,8 @@ const convertToCardProps = (
   }));
 
 const MyTradeHistoryPage = () => {
-  const searchParams = useSearchParams();
-  const initialTab = (searchParams.get('tab') as 'sell' | 'purchase') ?? 'sell';
-  const [activeTab, setActiveTab] = useState<'sell' | 'purchase'>(initialTab);
+  const { tab } = useTradeTabStore();
+  const [activeTab, setActiveTab] = useState(tab);
   const { sellTrade, purchaseTrade, setSellTrade, setPurchaseTrade } = useTradeHistory();
 
   const contentRef = useRef<HTMLDivElement>(null);

--- a/src/app/mypage/trade/page.tsx
+++ b/src/app/mypage/trade/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = 'force-dynamic';
+
 import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 import '@/styles/globals.css';

--- a/src/stores/useTradeTabStore.ts
+++ b/src/stores/useTradeTabStore.ts
@@ -1,13 +1,19 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-type TabType = 'sell' | 'purchase';
+type TabState = {
+  tab: 'sell' | 'purchase';
+  setTab: (tab: 'sell' | 'purchase') => void;
+};
 
-interface TradeTabStore {
-  tab: TabType;
-  setTab: (tab: TabType) => void;
-}
-
-export const useTradeTabStore = create<TradeTabStore>((set) => ({
-  tab: 'sell',
-  setTab: (tab) => set({ tab }),
-}));
+export const useTradeTabStore = create<TabState>()(
+  persist(
+    (set) => ({
+      tab: 'sell',
+      setTab: (tab) => set({ tab }),
+    }),
+    {
+      name: 'trade-tab',
+    },
+  ),
+);

--- a/src/stores/useTradeTabStore.ts
+++ b/src/stores/useTradeTabStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+type TabType = 'sell' | 'purchase';
+
+interface TradeTabStore {
+  tab: TabType;
+  setTab: (tap: TabType) => void;
+}
+
+export const useTradeTabStore = create<TradeTabStore>((set) => ({
+  tab: 'sell',
+  setTab: (tab) => set({ tab }),
+}));

--- a/src/stores/useTradeTabStore.ts
+++ b/src/stores/useTradeTabStore.ts
@@ -4,7 +4,7 @@ type TabType = 'sell' | 'purchase';
 
 interface TradeTabStore {
   tab: TabType;
-  setTab: (tap: TabType) => void;
+  setTab: (tab: TabType) => void;
 }
 
 export const useTradeTabStore = create<TradeTabStore>((set) => ({


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #228

### 🔎 작업 내용

- [x] 라우터 주소 수정
- [x] notification API 수정

### 📸 스크린샷 (선택)
<img width="835" height="59" alt="image" src="https://github.com/user-attachments/assets/732e95d9-d40b-466c-b7ec-7bb217558a58" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 판매 내역과 구매 내역 메뉴 클릭 시, 각각 쿼리 파라미터가 포함된 공통 거래 내역 페이지(`/mypage/trade`)로 이동하도록 변경되었습니다.
  * 거래 내역 페이지 진입 시, 저장된 탭 상태에 따라 초기 활성 탭(판매/구매)이 자동으로 설정됩니다.
  * 마이페이지 메뉴에 팔로우 목록과 알림 설정이 클릭 가능한 항목으로 추가되었습니다.
* **버그 수정 및 개선**
  * 알림 설정 API 호출에서 사용자 ID 하드코딩이 제거되어 동적 처리로 변경되었습니다.
  * 알림 설정 관련 타입과 API 메서드가 간소화되어 관리가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->