### PR TITLE
UF-189 판매 게시물 수정 및 삭제 API 구현

### DIFF
--- a/src/api/types/exchange.ts
+++ b/src/api/types/exchange.ts
@@ -16,11 +16,13 @@ export interface ExchangePost {
   createdAt: string;
   pricePerUnit: number;
   mobileDataType: MobileDataType;
+  sellerNickname: string;
+  sellerId: number;
 }
 
 export interface ExchangeCursor {
   createdAt: string;
-  cursorId: number;
+  id: number;
 }
 
 export interface GetExchangePostsRequest {

--- a/src/api/types/myInfo.ts
+++ b/src/api/types/myInfo.ts
@@ -6,7 +6,7 @@ export interface MyInfoResponse {
     email: string | null;
     sellMobileDataCapacityGb: number;
     sellableDataAmount: number;
-    zetAsset: number | null;
+    zetAsset: number;
     profileImageUrl?: string;
   };
 }

--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 
 import { sellAPI } from '@/api';
-import { AuthModal } from '@/features/exchange/components/AuthModal';
 import { ExchangeFilters } from '@/features/exchange/components/ExchangeFilters';
 import { ExchangeHeader } from '@/features/exchange/components/ExchangeHeader';
 import { ExchangeList } from '@/features/exchange/components/ExchangeList';
@@ -15,11 +14,7 @@ import queryClient from '@/utils/queryClient';
 
 export default function ExchangePage() {
   const router = useRouter();
-  const [authModal, setAuthModal] = useState({
-    isOpen: false,
-    title: '',
-    description: '',
-  });
+
   const [deleteModal, setDeleteModal] = useState({
     isOpen: false,
     postId: 0,
@@ -109,14 +104,6 @@ export default function ExchangePage() {
           onPurchase={handlePurchase}
         />
       </div>
-
-      {/* 인증 모달 */}
-      <AuthModal
-        isOpen={authModal.isOpen}
-        onClose={() => setAuthModal({ isOpen: false, title: '', description: '' })}
-        title={authModal.title}
-        description={authModal.description}
-      />
 
       {/* 삭제 확인 모달 */}
       <Modal

--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -41,6 +41,7 @@ export default function ExchangePage() {
       onSuccess: () => {
         setDeleteModal({ isOpen: false, postId: 0 });
         queryClient.invalidateQueries({ queryKey: ['exchangePosts'] });
+        setIsDeleting(false);
       },
       onError: (error) => {
         // 특정 에러 케이스 처리
@@ -57,8 +58,6 @@ export default function ExchangePage() {
         }, 1500);
       },
     });
-
-    setIsDeleting(false);
   };
 
   // 삭제 모달 닫기

--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -11,6 +11,7 @@ import { ExchangeHeader } from '@/features/exchange/components/ExchangeHeader';
 import { ExchangeList } from '@/features/exchange/components/ExchangeList';
 import { Title, Modal } from '@/shared';
 import { handleApiAction } from '@/utils/handleApiAction';
+import queryClient from '@/utils/queryClient';
 
 export default function ExchangePage() {
   const router = useRouter();
@@ -44,7 +45,7 @@ export default function ExchangePage() {
       errorMessage: '게시물 삭제 중 오류가 발생했습니다.',
       onSuccess: () => {
         setDeleteModal({ isOpen: false, postId: 0 });
-        window.location.reload();
+        queryClient.invalidateQueries({ queryKey: ['exchangePosts'] });
       },
       onError: (error) => {
         // 특정 에러 케이스 처리
@@ -57,7 +58,7 @@ export default function ExchangePage() {
         }
 
         setTimeout(() => {
-          window.location.reload();
+          queryClient.invalidateQueries({ queryKey: ['exchangePosts'] });
         }, 1500);
       },
     });

--- a/src/app/sell/edit/[id]/layout.tsx
+++ b/src/app/sell/edit/[id]/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+
+import { EditProvider } from '@/features/exchange/components/EditProvider';
+
+export const metadata: Metadata = {
+  title: 'UFO-Fi | 게시글 수정',
+  description: 'UFO-Fi 전파 거래소 게시글 수정 페이지',
+  robots: 'index, follow',
+};
+
+export default function EditLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-full w-full">
+      <EditProvider>{children}</EditProvider>
+    </div>
+  );
+}

--- a/src/app/sell/edit/[id]/page.tsx
+++ b/src/app/sell/edit/[id]/page.tsx
@@ -35,11 +35,6 @@ export default function SellEditPage() {
     }
   }, [postData]);
 
-  // 변경사항 감지
-  useEffect(() => {
-    if (!postData) return;
-  }, [titleInput, pricePerGB, value, postData]);
-
   // postData가 없으면 로딩 상태
   if (!postData) {
     return (

--- a/src/features/exchange/components/AuthModal.tsx
+++ b/src/features/exchange/components/AuthModal.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { Modal } from '@/shared';
+
+interface AuthModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+}
+
+export const AuthModal = ({
+  isOpen,
+  onClose,
+  title = '접근 권한 없음',
+  description = '본인이 작성한 글만 수정할 수 있습니다.\n다시 확인해 주세요.',
+}: AuthModalProps) => {
+  const router = useRouter();
+
+  const handleConfirm = () => {
+    onClose();
+    router.push('/exchange');
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      description={description}
+      type="single"
+      primaryButtonText="거래소로 돌아가기"
+      onPrimaryClick={handleConfirm}
+      closeOnPrimary={true}
+    />
+  );
+};

--- a/src/features/exchange/components/EditProvider.tsx
+++ b/src/features/exchange/components/EditProvider.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useRouter, useParams } from 'next/navigation';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+import { exchangeAPI } from '@/api';
+import { AuthModal } from '@/features/exchange/components/AuthModal';
+import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
+
+interface PostData {
+  title: string;
+  zetPerUnit: number;
+  capacity: number;
+  carrier: string;
+}
+
+interface EditContextType {
+  postData: PostData | null;
+  isLoading: boolean;
+  isAuthorized: boolean | null;
+}
+
+const EditContext = createContext<EditContextType>({
+  postData: null,
+  isLoading: true,
+  isAuthorized: null,
+});
+
+export const useEditContext = () => {
+  const context = useContext(EditContext);
+  if (!context) {
+    throw new Error('useEditContext must be used within EditProvider');
+  }
+  return context;
+};
+
+interface EditProviderProps {
+  children: React.ReactNode;
+}
+
+export const EditProvider = ({ children }: EditProviderProps) => {
+  const router = useRouter();
+  const params = useParams();
+  const { data: userInfo, isLoading: isUserLoading } = useMyInfo();
+
+  const [authModal, setAuthModal] = useState({
+    isOpen: false,
+    title: '접근 권한 없음',
+    description: '본인이 작성한 글만 수정할 수 있습니다.\n거래소로 돌아가겠습니다.',
+  });
+  const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
+  const [postData, setPostData] = useState<PostData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const checkOwnership = async () => {
+      if (isUserLoading || !userInfo || !params.id) return;
+
+      try {
+        setIsLoading(true);
+
+        // 게시글 정보를 API에서 가져와서 소유권 확인
+        const response = await exchangeAPI.getPosts();
+        const posts = response.posts || [];
+        const targetPost = posts.find((post) => post.postId === Number(params.id));
+
+        if (!targetPost) {
+          setAuthModal((prev) => ({
+            ...prev,
+            title: '게시글을 찾을 수 없습니다',
+            description: '삭제되었거나 존재하지 않는 게시글입니다.\n거래소로 돌아가겠습니다.',
+            isOpen: true,
+          }));
+          setIsAuthorized(false);
+          setIsLoading(false);
+          return;
+        }
+
+        // 게시글 작성자와 현재 사용자 비교
+        const isOwner = userInfo.nickname === targetPost.sellerNickname;
+
+        if (!isOwner) {
+          setAuthModal((prev) => ({ ...prev, isOpen: true }));
+          setIsAuthorized(false);
+        } else {
+          // 권한이 있으면 게시글 데이터를 상태에 저장
+          setPostData({
+            title: targetPost.title,
+            zetPerUnit: targetPost.pricePerUnit,
+            capacity: targetPost.sellMobileDataCapacityGb,
+            carrier: targetPost.carrier,
+          });
+          setIsAuthorized(true);
+        }
+      } catch (error) {
+        console.error('게시글 소유권 확인 실패:', error);
+        setAuthModal((prev) => ({
+          ...prev,
+          title: '오류가 발생했습니다',
+          description: '게시글 정보를 확인할 수 없습니다.\n거래소로 돌아가겠습니다.',
+          isOpen: true,
+        }));
+        setIsAuthorized(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkOwnership();
+  }, [userInfo, isUserLoading, params.id]);
+
+  const handleModalClose = () => {
+    setAuthModal((prev) => ({ ...prev, isOpen: false }));
+    router.push('/exchange');
+  };
+
+  // 로딩 중
+  if (isUserLoading || isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-white">권한을 확인하는 중...</div>
+      </div>
+    );
+  }
+
+  // 권한이 없는 경우
+  if (isAuthorized === false) {
+    return (
+      <AuthModal
+        isOpen={authModal.isOpen}
+        onClose={handleModalClose}
+        title={authModal.title}
+        description={authModal.description}
+      />
+    );
+  }
+
+  // 권한이 있는 경우 Context Provider로 감싸서 렌더링
+  return (
+    <EditContext.Provider value={{ postData, isLoading: false, isAuthorized }}>
+      {children}
+    </EditContext.Provider>
+  );
+};

--- a/src/features/exchange/components/ExchangeHeader.tsx
+++ b/src/features/exchange/components/ExchangeHeader.tsx
@@ -3,10 +3,12 @@
 import { useRouter } from 'next/navigation';
 
 import { ICON_PATHS } from '@/constants/icons';
+import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
 import { Button, Icon } from '@/shared';
 
 export const ExchangeHeader = () => {
   const router = useRouter();
+  const { data: userInfo, isLoading } = useMyInfo();
 
   const handleCharge = () => {
     router.push('/charge');
@@ -16,13 +18,17 @@ export const ExchangeHeader = () => {
     router.push('/exchange/notification');
   };
 
+  const zetBalance = userInfo?.zetAsset ?? 0;
+
   return (
     <>
       {/* 잔액 표시 */}
       <div className="text-right mb-2">
         <div className="inline-flex items-center gap-x-3 py-2">
           <Icon src={ICON_PATHS['COIN']} className="w-4 h-4" />
-          <span className="text-lg font-bold text-cyan-400">0 ZET</span>
+          <span className="text-lg font-bold text-cyan-400">
+            {isLoading ? '로딩 중...' : `${zetBalance.toLocaleString()} ZET`}
+          </span>
           <Button size="sm" onClick={handleCharge} className="w-auto rounded-md text-white text-sm">
             충전
           </Button>

--- a/src/features/exchange/components/ExchangeHeader.tsx
+++ b/src/features/exchange/components/ExchangeHeader.tsx
@@ -8,7 +8,7 @@ import { Button, Icon } from '@/shared';
 
 export const ExchangeHeader = () => {
   const router = useRouter();
-  const { data: userInfo, isLoading } = useMyInfo();
+  const { data: userInfo, isLoading, isError } = useMyInfo();
 
   const handleCharge = () => {
     router.push('/charge');
@@ -18,7 +18,11 @@ export const ExchangeHeader = () => {
     router.push('/exchange/notification');
   };
 
-  const zetBalance = userInfo?.zetAsset ?? 0;
+  const renderZetBalance = () => {
+    if (isLoading) return '로딩 중...';
+    if (isError || !userInfo) return '잔액 정보를 불러오지 못했어요.';
+    return `${userInfo.zetAsset.toLocaleString()} ZET`;
+  };
 
   return (
     <>
@@ -26,12 +30,16 @@ export const ExchangeHeader = () => {
       <div className="text-right mb-2">
         <div className="inline-flex items-center gap-x-3 py-2">
           <Icon src={ICON_PATHS['COIN']} className="w-4 h-4" />
-          <span className="text-lg font-bold text-cyan-400">
-            {isLoading ? '로딩 중...' : `${zetBalance.toLocaleString()} ZET`}
-          </span>
-          <Button size="sm" onClick={handleCharge} className="w-auto rounded-md text-white text-sm">
-            충전
-          </Button>
+          <span className="text-lg font-bold text-cyan-400">{renderZetBalance()}</span>
+          {!isError && userInfo && (
+            <Button
+              size="sm"
+              onClick={handleCharge}
+              className="w-auto rounded-md text-white text-sm"
+            >
+              충전
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/features/exchange/components/SellingItem.tsx
+++ b/src/features/exchange/components/SellingItem.tsx
@@ -8,6 +8,9 @@ interface SellingItemProps {
   price: string;
   timeLeft: string;
   isOwner?: boolean;
+  title: string;
+  sellerNickname: string;
+  sellerId: number;
   onEdit?: () => void;
   onDelete?: () => void;
   onReport?: () => void;
@@ -34,8 +37,10 @@ export default function SellingItem({
   networkType,
   capacity,
   price,
+  title,
   timeLeft,
   isOwner = false,
+  sellerNickname,
   onEdit,
   onDelete,
   onReport,
@@ -44,7 +49,7 @@ export default function SellingItem({
   const carrierIcon = getCarrierIcon(carrier);
 
   // 필수 props 유효성 검사만 진행
-  if (!carrier || !capacity || !price || !timeLeft) {
+  if (!title || !carrier || !capacity || !price || !timeLeft) {
     return null;
   }
 
@@ -84,7 +89,7 @@ export default function SellingItem({
       </div>
 
       {/* 콘텐츠 라인 */}
-      <div className="flex gap-4 items-start">
+      <div className="flex gap-4 items-center">
         {/* 아바타 */}
         <Avatar variant="selling" size="md">
           <Icon name="astronaut" className="w-8 h-8 text-purple-200" />
@@ -92,19 +97,26 @@ export default function SellingItem({
 
         {/* 정보 영역 */}
         <div className="flex-1 flex flex-col gap-1">
-          {/* 뱃지 */}
-          <Badge showIcon={false} variant="secondary">
-            <div className="flex items-center gap-1">
-              {carrierIcon && <Icon src={carrierIcon} alt={carrier} className="w-4 h-4" />}
-              <span>{`${carrier} ${networkType}`}</span>
-            </div>
-          </Badge>
+          {/* 뱃지 및 판매자 정보 */}
+          <div className="flex items-center justify-between">
+            <Badge showIcon={false} variant="secondary">
+              <div className="flex items-center gap-1">
+                {carrierIcon && <Icon src={carrierIcon} alt={carrier} className="w-4 h-4" />}
+                <span>{`${carrier} ${networkType}`}</span>
+              </div>
+            </Badge>
+          </div>
+
+          <span className="text-white text-xl font-bold">{title}</span>
 
           {/* 용량 + 가격 */}
           <div className="flex gap-2 items-baseline">
             <span className="text-white text-xl font-bold">{capacity}</span>
             <span className="text-cyan-300 text-xl font-bold">{price}</span>
           </div>
+
+          {/* 판매자 닉네임 표시 */}
+          {sellerNickname && <span className="text-gray-300 text-xs">by {sellerNickname}</span>}
 
           {/* 시간 + 구매 버튼 한 줄 정렬 */}
           <div className="flex justify-between items-center">

--- a/src/features/exchange/components/SellingItem.tsx
+++ b/src/features/exchange/components/SellingItem.tsx
@@ -48,11 +48,6 @@ export default function SellingItem({
 }: SellingItemProps) {
   const carrierIcon = getCarrierIcon(carrier);
 
-  // 필수 props 유효성 검사만 진행
-  if (!title || !carrier || !capacity || !price || !timeLeft) {
-    return null;
-  }
-
   return (
     <div className="relative p-4 rounded-2xl border border-white/10 gradient-card-1">
       {/* 오른쪽 상단 버튼 */}

--- a/src/features/exchange/hooks/useInfiniteExchangePosts.ts
+++ b/src/features/exchange/hooks/useInfiniteExchangePosts.ts
@@ -13,7 +13,12 @@ export const useInfiniteExchangePosts = (params?: Omit<GetExchangePostsRequest, 
         size: 10,
       }),
     initialPageParam: undefined as number | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor?.cursorId ?? undefined,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.nextCursor || !lastPage.nextCursor.id) {
+        return undefined;
+      }
+      return lastPage.nextCursor.id;
+    },
     staleTime: 0, // 캐시 무효화
     refetchInterval: 10 * 1000, // 10초마다 polling
     refetchOnWindowFocus: true, // 탭 전환 시 자동 refetch


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #165 

### 🔎 작업 내용

- [x] 판매 게시물 수정 및 삭제 API 구현

### 📸 스크린샷 (선택)
> 본인 게시물이면 삭제 및 수정 버튼, 아니면 구매하기 버튼 렌더링 
<img width="284" height="611" alt="image" src="https://github.com/user-attachments/assets/3d584f40-fddf-4497-be95-7f5091d1bade" />

> 게시물 수정 페이지 (sell/edit/`postId`)

<img width="284" height="611" alt="image" src="https://github.com/user-attachments/assets/c42347e6-bb2f-4ae1-a921-7ee56be9d4ee" />

> 본인 게시물이 아닌 걸 수정하려고 강제로 이동 시 전역 모달로 방어
<img width="284" height="611" alt="image" src="https://github.com/user-attachments/assets/3ca89893-d44f-406b-badf-60406c9b940c" />

> 게시물 삭제 모달
<img width="284" height="611" alt="image" src="https://github.com/user-attachments/assets/5a8cb04a-b32d-4fd7-af8e-0f7378cfa006" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 게시글 삭제 시 브라우저 기본 confirm 대신 모달 기반 삭제 확인 기능 추가
  * 게시글 수정 페이지에 권한 확인 및 인증 모달 도입
  * 판매자 닉네임 및 ID 정보가 게시글 목록과 상세에 표시됨
  * 거래소 헤더에서 내 ZET 잔액을 실시간으로 표시
  * 인증 모달 컴포넌트 추가 및 권한 없는 접근 시 거래소로 리다이렉트 기능 구현

* **버그 수정**
  * 게시글 목록의 무한 스크롤에서 모든 게시글 로드 시 안내 메시지 조건 개선
  * 게시글 삭제 시 발생 가능한 특정 오류(HTTP 410, 403)에 대한 안내 토스트 메시지 추가

* **리팩터**
  * 게시글 수정 페이지에서 URL 파라미터 대신 컨텍스트 기반 데이터 로딩으로 전환
  * 게시글 목록, 아이템, 수정 관련 컴포넌트의 props 및 내부 로직 구조 개선
  * 삭제 기능 로직 분리 및 비동기 처리 개선

* **문서화**
  * 각 페이지 및 컴포넌트에 메타데이터 및 설명 추가

* **기타**
  * 판매글 데이터 타입에 판매자 정보 필드 추가 및 페이징 커서 필드명 변경
  * 사용자 정보 타입에서 ZET 자산 필드의 null 허용 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->