### PR TITLE
UF-249 Title 컴포넌트 스토리북 호환성 개선

### DIFF
--- a/src/app/blackhole/page.tsx
+++ b/src/app/blackhole/page.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 
 import { IMAGE_PATHS } from '@/constants/images';
-import { Title } from '@/shared/ui';
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
 
 function BlackholePageInner() {
   const searchParams = useSearchParams();
@@ -13,7 +13,7 @@ function BlackholePageInner() {
 
   return (
     <div className="flex flex-col items-center min-h-full w-full">
-      <Title title="홈" iconVariant="back" className="mb-0" />
+      <TitleWithRouter title="홈" iconVariant="back" className="mb-0" />
       <div className="flex flex-col items-center w-full flex-1 justify-center">
         <p className="text-lg font-bold text-white text-center mb-2">
           {mode === 'self'

--- a/src/app/charge/page.tsx
+++ b/src/app/charge/page.tsx
@@ -4,7 +4,8 @@ import { IMAGE_PATHS } from '@/constants/images';
 import { PACKAGES } from '@/constants/packages';
 import { ZetChargePackageCard } from '@/features/charge/components/ZetChargePackageCard';
 import { useZetCharge } from '@/features/charge/hooks/useZetCharge';
-import { Icon, Title } from '@/shared';
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
+import { Icon } from '@/shared';
 import '@/styles/globals.css';
 
 export default function ZetChargePage() {
@@ -14,7 +15,7 @@ export default function ZetChargePage() {
     <div className="relative min-h-full flex flex-col">
       <div className="px-4 pt-4">
         <div className="flex items-center justify-between mb-2">
-          <Title title="ZET 코인 충전소" iconVariant="back" />
+          <TitleWithRouter title="ZET 코인 충전소" iconVariant="back" />
         </div>
         <div className="flex items-center justify-between mb-4">
           <p className="body-16-medium text-white m-0">외계 전파 코인을 구매하세요!</p>

--- a/src/app/exchange/bulk/page.tsx
+++ b/src/app/exchange/bulk/page.tsx
@@ -7,7 +7,7 @@ import { ICON_PATHS } from '@/constants/icons';
 import { IMAGE_PATHS } from '@/constants/images';
 import { BulkCapacitySlider } from '@/features/bulk/components/BulkCapacitySlider';
 import { useBulkPurchase } from '@/features/bulk/hooks/useBulkPurchase';
-import { Icon, Title, Button, PriceInput } from '@/shared';
+import { Icon, TitleWithRouter, Button, PriceInput } from '@/shared';
 import { useViewportStore } from '@/stores/useViewportStore';
 
 export default function BulkPurchasePage() {
@@ -31,7 +31,7 @@ export default function BulkPurchasePage() {
 
   return (
     <div className="flex flex-col min-h-full w-full justify-center">
-      <Title title="일괄구매" iconVariant="back" />
+      <TitleWithRouter title="일괄구매" iconVariant="back" />
       <div className="relative rounded-[20px] space-y-6 pb-12">
         {/* 거래 제안서 헤더 */}
         <div className="flex items-center space-x-3">

--- a/src/app/exchange/bulk/result/index.tsx
+++ b/src/app/exchange/bulk/result/index.tsx
@@ -6,7 +6,8 @@ import { Suspense } from 'react';
 import { ICON_PATHS } from '@/constants/icons';
 import { BulkResultCard } from '@/features/bulk/components/BulkResultCard';
 import { useBulkResult } from '@/features/bulk/hooks/useBulkResult';
-import { Icon, Title, Button } from '@/shared';
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
+import { Icon, Button } from '@/shared';
 import { useViewportStore } from '@/stores/useViewportStore';
 
 function BulkResultContent() {
@@ -21,7 +22,7 @@ function BulkResultContent() {
 
   return (
     <div className="flex flex-col min-h-full w-full">
-      <Title title="매칭된 데이터" iconVariant="back" />
+      <TitleWithRouter title="매칭된 데이터" iconVariant="back" />
 
       <div className="relative rounded-[20px] space-y-6 pb-12 px-4">
         {/* 매칭 결과 */}

--- a/src/app/exchange/notification/page.tsx
+++ b/src/app/exchange/notification/page.tsx
@@ -9,7 +9,7 @@ import { Carrier, CARRIER_DISPLAY_NAMES } from '@/api/types/carrier';
 import { FilterBox } from '@/features/exchange/components/FilterBox';
 import { useFilteredItemCount } from '@/hooks/useFilteredItemCount';
 import { useFilterState } from '@/hooks/useFilterState';
-import { Button, Chip, DataRangeSlider, DataSlider, Icon, Title } from '@/shared';
+import { Button, Chip, DataRangeSlider, DataSlider, Icon, TitleWithRouter } from '@/shared';
 
 import '@/styles/globals.css';
 
@@ -103,7 +103,7 @@ const FilterNotificationPage = () => {
 
   return (
     <div className="flex flex-col justify-start items-center w-full min-h-full">
-      <Title title="알림 조건 설정" iconVariant="back" />
+      <TitleWithRouter title="알림 조건 설정" iconVariant="back" />
       <div className="overflow-y-auto flex flex-col gap-4 h-full mb-4 hide-scrollbar">
         {/* 통신사 선택 */}
         <FilterBox name="통신사" isMultipleSelection={true}>

--- a/src/app/mypage/edit-profile/page.tsx
+++ b/src/app/mypage/edit-profile/page.tsx
@@ -2,9 +2,9 @@
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
 import { ConfirmModal, NicknameEditor, PlanEditor } from '@/features/mypage/components';
 import { useEditProfile } from '@/features/mypage/hooks/useEditProfile';
-import { Title } from '@/shared';
 
 export default function EditProfilePage() {
   const router = useRouter();
@@ -38,7 +38,7 @@ export default function EditProfilePage() {
 
   return (
     <div className="flex flex-col min-h-screen w-full">
-      <Title title="프로필 수정" iconVariant="back" />
+      <TitleWithRouter title="프로필 수정" iconVariant="back" />
       <div className="mx-4 mt-6 flex flex-col gap-8">
         <NicknameEditor
           nickname={nickname}

--- a/src/app/mypage/follow/page.tsx
+++ b/src/app/mypage/follow/page.tsx
@@ -2,12 +2,13 @@
 
 import { useMemo } from 'react';
 
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
 import FollowTabContent from '@/features/mypage/follow/components/FollowTabContent';
 import { useFollowActions } from '@/features/mypage/follow/hooks/useFollowActions';
 import { useFollowers } from '@/features/mypage/follow/hooks/useFollowers';
 import { useFollowing } from '@/features/mypage/follow/hooks/useFollowing';
 import { FOLLOW_TYPE } from '@/features/mypage/follow/types/FollowType.types';
-import { Title, Tabs, TabsList, TabsTrigger, TabsContent } from '@/shared/ui';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/shared/ui';
 
 export default function Page() {
   const { data: followersData, isLoading: followersLoading } = useFollowers();
@@ -60,7 +61,7 @@ export default function Page() {
 
   return (
     <div className="min-h-screen w-full text-white">
-      <Title title="팔로우 목록" iconVariant="back" />
+      <TitleWithRouter title="팔로우 목록" iconVariant="back" />
 
       <div className="mx-4 mb-6">
         <Tabs defaultValue="followers">

--- a/src/app/mypage/privacy/page.tsx
+++ b/src/app/mypage/privacy/page.tsx
@@ -3,13 +3,13 @@
 import React from 'react';
 
 import privacyRaw from '@/assets/terms/privacy.md?raw';
-import { Title } from '@/shared';
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
 import { renderTermsWithHeadingsAndLinks } from '@/shared/utils/termsRenderer';
 
 export default function TermsPage() {
   return (
     <div>
-      <Title title="개인정보 처리방침" iconVariant="back" />
+      <TitleWithRouter title="개인정보 처리방침" iconVariant="back" />
       <div className="text-white overflow-y-auto text-sm max-h-[80vh] p-2 rounded-lg flex flex-col gap-1 leading-relaxed hide-scrollbar">
         {renderTermsWithHeadingsAndLinks(privacyRaw)}
       </div>

--- a/src/app/mypage/service/page.tsx
+++ b/src/app/mypage/service/page.tsx
@@ -3,13 +3,13 @@
 import React from 'react';
 
 import serviceRaw from '@/assets/terms/service.md?raw';
-import { Title } from '@/shared';
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
 import { renderTermsWithHeadingsAndLinks } from '@/shared/utils/termsRenderer';
 
 export default function TermsPage() {
   return (
     <div>
-      <Title title="이용약관" iconVariant="back" />
+      <TitleWithRouter title="이용약관" iconVariant="back" />
       <div className="text-white overflow-y-auto text-sm max-h-[80vh] p-2 rounded-lg flex flex-col gap-1 leading-relaxed hide-scrollbar">
         {renderTermsWithHeadingsAndLinks(serviceRaw)}
       </div>

--- a/src/app/payment/password/page.tsx
+++ b/src/app/payment/password/page.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from 'react';
 
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
 import PasswordPad from '@/features/payment/components/PasswordPad';
 import { PaymentCancellationModal } from '@/features/payment/components/PaymentCancellationModal';
-import { Title } from '@/shared/ui';
 
 export default function PaymentPasswordPage() {
   const [step, setStep] = useState<'register' | 'confirm'>('register');
@@ -39,7 +39,7 @@ export default function PaymentPasswordPage() {
 
   return (
     <div className="w-full  text-white px-4 py-6 space-y-8">
-      <Title title="비밀번호 입력" iconVariant="back" />
+      <TitleWithRouter title="비밀번호 입력" iconVariant="back" />
       <div className="flex-1 flex items-center justify-center">
         <PasswordPad
           key={step === 'register' ? 'register' : `confirm-${errorCount}`}

--- a/src/app/sell/edit/[id]/page.tsx
+++ b/src/app/sell/edit/[id]/page.tsx
@@ -11,7 +11,7 @@ import { useEditContext } from '@/features/exchange/components/EditProvider';
 import { SellCapacitySlider } from '@/features/sell/components/SellCapacitySlider';
 import { SellTotalPrice } from '@/features/sell/components/SellTotalPrice';
 import { getSellErrorMessages } from '@/features/sell/utils/sellValidation';
-import { Icon, Input, Title, Button, PriceInput } from '@/shared';
+import { Icon, Input, TitleWithRouter, Button, PriceInput } from '@/shared';
 import { useViewportStore } from '@/stores/useViewportStore';
 import { handleApiAction } from '@/utils/handleApiAction';
 
@@ -81,7 +81,7 @@ export default function SellEditPage() {
 
   return (
     <div className="flex flex-col min-h-full w-full justify-center">
-      <Title title="데이터 판매 수정" iconVariant="back" />
+      <TitleWithRouter title="데이터 판매 수정" iconVariant="back" />
       <div className="relative rounded-[20px] space-y-6 pb-16 xs:pb-32">
         {/* 거래명세서 타이틀 */}
         <div className="flex items-center space-x-3">

--- a/src/features/bulk/components/BulkResultContent.tsx
+++ b/src/features/bulk/components/BulkResultContent.tsx
@@ -7,7 +7,7 @@ import { bulkPurchaseAPI } from '@/api/services/exchange/bulkPurchase';
 import { purchaseAPI } from '@/api/services/exchange/purchase';
 import { ICON_PATHS } from '@/constants/icons';
 import { BulkResultCard } from '@/features/bulk/components/BulkResultCard';
-import { Icon, Title, Button } from '@/shared';
+import { Icon, TitleWithRouter, Button } from '@/shared';
 import { useViewportStore } from '@/stores/useViewportStore';
 
 import { useBulkPurchase } from '../hooks/useBulkPurchase';
@@ -104,7 +104,7 @@ export function BulkResultContent({ initialData }: BulkResultContentProps) {
   if (error || !resultData) {
     return (
       <div className="flex flex-col min-h-screen">
-        <Title title="매칭된 데이터" iconVariant="back" />
+        <TitleWithRouter title="매칭된 데이터" iconVariant="back" />
         <div className="w-full h-full flex items-center justify-center text-white">
           검색 결과를 찾을 수 없습니다.
         </div>
@@ -115,7 +115,7 @@ export function BulkResultContent({ initialData }: BulkResultContentProps) {
   // 정상 상태
   return (
     <div className="flex flex-col min-h-full w-full">
-      <Title title="매칭된 데이터" iconVariant="back" />
+      <TitleWithRouter title="매칭된 데이터" iconVariant="back" />
       <div className="px-4">
         <BulkResultDisplay
           data={resultData}

--- a/src/features/common/components/TitleWithRouter.tsx
+++ b/src/features/common/components/TitleWithRouter.tsx
@@ -6,9 +6,12 @@ import React from 'react';
 import { Title } from '../../../shared/ui/Title/Title';
 import type { TitleProps } from '../../../shared/ui/Title/Title.types';
 
-export const TitleWithRouter: React.FC<TitleProps> = (props) => {
+export const TitleWithRouter: React.FC<TitleProps> = ({
+  onIconClick,
+  iconVariant,
+  ...restProps
+}) => {
   const router = useRouter();
-  const { onIconClick, iconVariant } = props;
 
   const handleIconClick = React.useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -21,5 +24,5 @@ export const TitleWithRouter: React.FC<TitleProps> = (props) => {
     [onIconClick, iconVariant, router],
   );
 
-  return <Title {...props} onIconClick={handleIconClick} />;
+  return <Title {...restProps} iconVariant={iconVariant} onIconClick={handleIconClick} />;
 };

--- a/src/features/common/components/TitleWithRouter.tsx
+++ b/src/features/common/components/TitleWithRouter.tsx
@@ -3,8 +3,8 @@
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
-import { Title } from './Title';
-import type { TitleProps } from './Title.types';
+import { Title } from '../../../shared/ui/Title/Title';
+import type { TitleProps } from '../../../shared/ui/Title/Title.types';
 
 export const TitleWithRouter: React.FC<TitleProps> = (props) => {
   const router = useRouter();

--- a/src/features/profile/components/DataListView/index.tsx
+++ b/src/features/profile/components/DataListView/index.tsx
@@ -2,8 +2,8 @@
 
 import { useRouter } from 'next/navigation';
 
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
 import { useProfile } from '@/features/profile/hooks/useProfile';
-import { Title } from '@/shared';
 
 import { SimpleDataCard } from './SimpleDataCard';
 
@@ -36,7 +36,7 @@ export function DataListView({ userId }: DataListViewProps) {
 
   return (
     <div className="flex flex-col min-h-full w-full pb-6">
-      <Title title="판매중인 데이터 목록" iconVariant="back" />
+      <TitleWithRouter title="판매중인 데이터 목록" iconVariant="back" />
 
       <div className="px-4 space-y-4">
         <div className="space-y-4">

--- a/src/features/profile/components/ProfileShare/ShareButtons.tsx
+++ b/src/features/profile/components/ProfileShare/ShareButtons.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { FreeMode } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 import type { ProfileUser } from '@/api/types/profile';
@@ -14,7 +13,6 @@ import {
 import { Button, Icon } from '@/shared';
 
 import 'swiper/css';
-import 'swiper/css/free-mode';
 
 interface ShareButtonsProps {
   profile: ProfileUser;
@@ -114,13 +112,7 @@ export function ShareButtons({ profile, profileUrl, onCopyLink, onClose }: Share
     <div className="space-y-6">
       {/* 스와이퍼로 가로 스크롤 */}
       <div className="w-full">
-        <Swiper
-          modules={[FreeMode]}
-          spaceBetween={16}
-          slidesPerView="auto"
-          freeMode={true}
-          className="!px-4"
-        >
+        <Swiper spaceBetween={16} slidesPerView="auto" freeMode={true} className="!px-4">
           {shareOptions.map((option) => (
             <SwiperSlide key={option.id} className="!w-auto">
               <button

--- a/src/features/profile/components/ProfileShare/ShareButtons.tsx
+++ b/src/features/profile/components/ProfileShare/ShareButtons.tsx
@@ -13,6 +13,7 @@ import {
 import { Button, Icon } from '@/shared';
 
 import 'swiper/css';
+import 'swiper/css/free-mode';
 
 interface ShareButtonsProps {
   profile: ProfileUser;

--- a/src/features/profile/components/ProfileView/index.tsx
+++ b/src/features/profile/components/ProfileView/index.tsx
@@ -2,8 +2,8 @@
 
 import { useRouter } from 'next/navigation';
 
+import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
 import { useProfile } from '@/features/profile/hooks/useProfile';
-import { Title } from '@/shared';
 
 import { ProfileContentSections } from './ProfileContentSections';
 import { ProfileHeader } from './ProfileHeader';
@@ -50,7 +50,7 @@ export function ProfileView({ userId }: ProfileViewProps) {
 
   return (
     <div className="flex flex-col min-h-full w-full pb-6">
-      <Title title="프로필 보기" iconVariant="back" />
+      <TitleWithRouter title="프로필 보기" iconVariant="back" />
 
       <div className="space-y-6 px-4">
         <ProfileHeader profile={profile} />

--- a/src/shared/ui/Title/Title.tsx
+++ b/src/shared/ui/Title/Title.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -28,7 +27,6 @@ export const Title: React.FC<TitleProps> = ({
   className,
   ...props
 }) => {
-  const router = useRouter();
   const iconName = getIconName(iconVariant);
   const hasIcon = iconName !== null;
 
@@ -37,11 +35,11 @@ export const Title: React.FC<TitleProps> = ({
     (e: React.MouseEvent<HTMLButtonElement>): void => {
       if (onIconClick) {
         onIconClick(e);
-      } else if (iconVariant === 'back') {
-        router.back();
       }
+      // iconVariant === 'back'이고 onIconClick이 없으면 아무 동작하지 않음
+      // 실제 앱에서는 TitleWithRouter를 사용하여 router.back() 호출
     },
-    [onIconClick, iconVariant, router],
+    [onIconClick],
   );
 
   return (

--- a/src/shared/ui/Title/TitleWithRouter.tsx
+++ b/src/shared/ui/Title/TitleWithRouter.tsx
@@ -8,16 +8,17 @@ import type { TitleProps } from './Title.types';
 
 export const TitleWithRouter: React.FC<TitleProps> = (props) => {
   const router = useRouter();
+  const { onIconClick, iconVariant } = props;
 
   const handleIconClick = React.useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
-      if (props.onIconClick) {
-        props.onIconClick(e);
-      } else if (props.iconVariant === 'back') {
+      if (onIconClick) {
+        onIconClick(e);
+      } else if (iconVariant === 'back') {
         router.back();
       }
     },
-    [props, router],
+    [onIconClick, iconVariant, router],
   );
 
   return <Title {...props} onIconClick={handleIconClick} />;

--- a/src/shared/ui/Title/TitleWithRouter.tsx
+++ b/src/shared/ui/Title/TitleWithRouter.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+import { Title } from './Title';
+import type { TitleProps } from './Title.types';
+
+export const TitleWithRouter: React.FC<TitleProps> = (props) => {
+  const router = useRouter();
+
+  const handleIconClick = React.useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (props.onIconClick) {
+        props.onIconClick(e);
+      } else if (props.iconVariant === 'back') {
+        router.back();
+      }
+    },
+    [props, router],
+  );
+
+  return <Title {...props} onIconClick={handleIconClick} />;
+};

--- a/src/shared/ui/Title/index.ts
+++ b/src/shared/ui/Title/index.ts
@@ -1,2 +1,3 @@
 export { Title } from './Title';
+export { TitleWithRouter } from './TitleWithRouter';
 export type { TitleProps, TitleIconVariant } from './Title.types';

--- a/src/shared/ui/Title/index.ts
+++ b/src/shared/ui/Title/index.ts
@@ -1,3 +1,3 @@
 export { Title } from './Title';
-export { TitleWithRouter } from '../../../features/common/components/TitleWithRouter';
+export { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
 export type { TitleProps, TitleIconVariant } from './Title.types';

--- a/src/shared/ui/Title/index.ts
+++ b/src/shared/ui/Title/index.ts
@@ -1,3 +1,3 @@
 export { Title } from './Title';
-export { TitleWithRouter } from './TitleWithRouter';
+export { TitleWithRouter } from '../../../features/common/components/TitleWithRouter';
 export type { TitleProps, TitleIconVariant } from './Title.types';


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #252 

### 🔎 작업 내용

- [x] useRouter 의존성 제거로 스토리북 렌더링 오류 해결
- [x] TitleWithRouter 래퍼 컴포넌트 추가로 Next.js 앱에서 router 기능 제공
- [x] 불필요한 의존성 제거 및 리턴 오류 수 
### 📸 스크린샷 (선택)
<img width="333" height="74" alt="image" src="https://github.com/user-attachments/assets/22b3ccb0-24f1-4622-8aa5-c49811c715f0" />
<img width="334" height="75" alt="image" src="https://github.com/user-attachments/assets/c07378d2-207f-4bc6-87ea-ad9af31ed02f" />
<img width="333" height="74" alt="image" src="https://github.com/user-attachments/assets/7200ab5a-a32e-4432-9199-92a19c63bda2" />

### 📢 전달사항
타이틀 작업하는 과정에서 다른 컴포넌트들의 오류가 발생하여 아래와 같은 작업을 실시하였습니다.
- FreeMode 모듈 import 제거 (v11에서는 기본 포함)
- Css import 제거
- modules 배열에서 FreeMode 제거
- Next.js 환경에서 Swiper 정상 작동하도록 수정

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 아이콘 클릭 시 뒤로 가기 기능이 내장된 새로운 TitleWithRouter 컴포넌트가 추가되었습니다.

* **Refactor**
  * 여러 페이지 및 컴포넌트에서 기존 Title 컴포넌트 사용을 TitleWithRouter로 교체하여 일관된 뒤로 가기 동작을 제공합니다.
  * Swiper 관련 불필요한 모듈 import 및 props가 정리되어 코드가 간결해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->