### PR TITLE
UF-252 테이블 컴포넌트에 페이지네이션 기능 추가

### DIFF
--- a/src/features/user-management/components/UserTable.tsx
+++ b/src/features/user-management/components/UserTable.tsx
@@ -28,6 +28,7 @@ const UserTable: React.FC<UserTableProps> = ({ data, onActivateClick, onDeactiva
       data={data}
       onActivateClick={onActivateClick}
       onDeactivateClick={onDeactivateClick}
+      showPagination={true}
     />
   );
 };

--- a/src/shared/hooks/usePagination.ts
+++ b/src/shared/hooks/usePagination.ts
@@ -18,7 +18,7 @@ export const usePagination = ({
   siblingCount = 1,
 }: UsePaginationProps): UsePaginationReturn => {
   const pageNumbers = useMemo(() => {
-    if (totalPages <= 1) return [];
+    if (totalPages <= 1) return [1];
 
     // 페이지 번호 배열 생성 로직
     const range = (start: number, end: number) => {

--- a/src/shared/ui/Pagination/Pagination.tsx
+++ b/src/shared/ui/Pagination/Pagination.tsx
@@ -23,7 +23,7 @@ const Pagination: React.FC<PaginationProps> = ({
     siblingCount,
   });
 
-  if (total <= 1 || !pageNumbers.length) return null;
+  if (!pageNumbers.length) return null;
 
   const DOTS = '...';
 

--- a/src/shared/ui/Table/Table.stories.tsx
+++ b/src/shared/ui/Table/Table.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
 
 import { Table } from './Table';
 import { Icon } from '../Icons/Icon';
@@ -31,52 +32,90 @@ const defaultActions = {
   activateIcon: <Icon name="return" className="w-5 h-5" />,
 };
 
-const data = [
-  {
-    id: 1,
-    nickname: 'caddibo4',
-    name: '김도건',
-    email: 'caddibo4@naver.com',
-    reportedCount: 9999,
-    disabledCount: 9999,
-    status: '활성화',
+//테스트 데이터
+const generateTestData = (count: number) => {
+  return Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    nickname: `user${index + 1}`,
+    name: `사용자${index + 1}`,
+    email: `user${index + 1}@example.com`,
+    reportedCount: Math.floor(Math.random() * 100),
+    disabledCount: Math.floor(Math.random() * 50),
+    status: index % 3 === 0 ? '비활성화' : '활성화',
     actions: defaultActions,
-  },
-  {
-    id: 2,
-    nickname: 'yj.Jee',
-    name: '이영주',
-    email: 'caddibo4@naver.com',
-    reportedCount: 99999,
-    disabledCount: 99999,
-    status: '비활성화',
-    actions: defaultActions,
-  },
-  {
-    id: 3,
-    nickname: 'jy.Ho',
-    name: '진영호',
-    email: 'caddibo4@naver.com',
-    reportedCount: 99999,
-    disabledCount: 99999,
-    status: '비활성화',
-    actions: defaultActions,
-  },
-  {
-    id: 4,
-    nickname: 'mj.An',
-    name: '안민지',
-    email: 'caddibo4@naver.com',
-    reportedCount: 99999,
-    disabledCount: 99999,
-    status: '비활성화',
-    actions: defaultActions,
-  },
-];
+  }));
+};
+
+const data = generateTestData(25); // 25개의 테스트 데이터
 
 export const Default: Story = {
   args: {
     columns,
     data,
+  },
+};
+
+export const WithPagination: Story = {
+  render: function WithPaginationStory() {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+
+    return (
+      <div className="p-6">
+        <Table
+          columns={columns}
+          data={data}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          showPagination={true}
+        />
+      </div>
+    );
+  },
+};
+
+export const LargeDataset: Story = {
+  render: function LargeDatasetStory() {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(20);
+    const largeData = generateTestData(100); // 100개의 테스트 데이터
+
+    return (
+      <div className="p-6">
+        <Table
+          columns={columns}
+          data={largeData}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          showPagination={true}
+        />
+      </div>
+    );
+  },
+};
+
+export const SmallDataset: Story = {
+  render: function SmallDatasetStory() {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+    const smallData = generateTestData(5); // 5개의 테스트 데이터 (1페이지)
+
+    return (
+      <div className="p-6">
+        <Table
+          columns={columns}
+          data={smallData}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          showPagination={true}
+        />
+      </div>
+    );
   },
 };

--- a/src/shared/ui/Table/Table.stories.tsx
+++ b/src/shared/ui/Table/Table.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Table } from './Table';
 import { Icon } from '../Icons/Icon';
@@ -57,20 +57,9 @@ export const Default: Story = {
 
 export const WithPagination: Story = {
   render: function WithPaginationStory() {
-    const [page, setPage] = useState(1);
-    const [pageSize, setPageSize] = useState(10);
-
     return (
       <div className="p-6">
-        <Table
-          columns={columns}
-          data={data}
-          page={page}
-          pageSize={pageSize}
-          onPageChange={setPage}
-          onPageSizeChange={setPageSize}
-          showPagination={true}
-        />
+        <Table columns={columns} data={data} showPagination={true} />
       </div>
     );
   },
@@ -78,21 +67,11 @@ export const WithPagination: Story = {
 
 export const LargeDataset: Story = {
   render: function LargeDatasetStory() {
-    const [page, setPage] = useState(1);
-    const [pageSize, setPageSize] = useState(20);
     const largeData = generateTestData(100); // 100개의 테스트 데이터
 
     return (
       <div className="p-6">
-        <Table
-          columns={columns}
-          data={largeData}
-          page={page}
-          pageSize={pageSize}
-          onPageChange={setPage}
-          onPageSizeChange={setPageSize}
-          showPagination={true}
-        />
+        <Table columns={columns} data={largeData} showPagination={true} />
       </div>
     );
   },
@@ -100,21 +79,11 @@ export const LargeDataset: Story = {
 
 export const SmallDataset: Story = {
   render: function SmallDatasetStory() {
-    const [page, setPage] = useState(1);
-    const [pageSize, setPageSize] = useState(10);
     const smallData = generateTestData(5); // 5개의 테스트 데이터 (1페이지)
 
     return (
       <div className="p-6">
-        <Table
-          columns={columns}
-          data={smallData}
-          page={page}
-          pageSize={pageSize}
-          onPageChange={setPage}
-          onPageSizeChange={setPageSize}
-          showPagination={true}
-        />
+        <Table columns={columns} data={smallData} showPagination={true} />
       </div>
     );
   },

--- a/src/shared/ui/Table/Table.tsx
+++ b/src/shared/ui/Table/Table.tsx
@@ -21,10 +21,7 @@ interface TableProps<T extends TableRowBase> {
   onActivateClick?: (row: T) => void;
   onDeactivateClick?: (row: T) => void;
   // 페이지네이션 관련 props
-  page?: number;
   pageSize?: number;
-  onPageChange?: (page: number) => void;
-  onPageSizeChange?: (size: number) => void;
   showPagination?: boolean;
 }
 
@@ -33,12 +30,12 @@ const Table = <T extends TableRowBase>({
   data,
   onActivateClick,
   onDeactivateClick,
-  page = 1,
   pageSize = 10,
-  onPageChange,
-  onPageSizeChange,
   showPagination = false,
 }: TableProps<T>) => {
+  const [page, setPage] = React.useState(1);
+  const [currentPageSize, setCurrentPageSize] = React.useState(pageSize);
+
   const handleActivate = (row: T) => {
     onActivateClick?.(row);
   };
@@ -47,9 +44,9 @@ const Table = <T extends TableRowBase>({
   };
 
   // 페이지네이션을 위한 데이터 슬라이싱
-  const totalPages = Math.ceil(data.length / pageSize);
-  const startIndex = (page - 1) * pageSize;
-  const endIndex = startIndex + pageSize;
+  const totalPages = Math.ceil(data.length / currentPageSize);
+  const startIndex = (page - 1) * currentPageSize;
+  const endIndex = startIndex + currentPageSize;
   const paginatedData = data.slice(startIndex, endIndex);
 
   return (
@@ -124,26 +121,27 @@ const Table = <T extends TableRowBase>({
       </div>
 
       {/* 페이지네이션 */}
-      {showPagination && data.length > 0 && onPageChange && (
+      {showPagination && data.length > 0 && (
         <div className="flex items-center justify-between">
           {/* 페이지 크기 선택 */}
-          {onPageSizeChange && (
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-600">페이지당 행 수:</span>
-              <select
-                value={pageSize}
-                onChange={(e) => onPageSizeChange(Number(e.target.value))}
-                className="px-2 py-1 border border-gray-300 rounded text-sm"
-              >
-                <option value={10}>10</option>
-                <option value={20}>20</option>
-                <option value={50}>50</option>
-              </select>
-            </div>
-          )}
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-600">페이지당 행 수:</span>
+            <select
+              value={currentPageSize}
+              onChange={(e) => {
+                setCurrentPageSize(Number(e.target.value));
+                setPage(1); // 페이지 크기 변경 시 첫 페이지로 이동
+              }}
+              className="px-2 py-1 border border-gray-300 rounded text-sm"
+            >
+              <option value={10}>10</option>
+              <option value={20}>20</option>
+              <option value={50}>50</option>
+            </select>
+          </div>
 
           {/* 페이지네이션 컴포넌트 */}
-          <Pagination page={page} total={totalPages} onChange={onPageChange} className="flex-1" />
+          <Pagination page={page} total={totalPages} onChange={setPage} className="flex-1" />
 
           {/* 데이터 정보 */}
           <div className="text-sm text-gray-600">

--- a/src/shared/ui/Table/Table.tsx
+++ b/src/shared/ui/Table/Table.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import { CircleMinusIcon, ReturnIcon } from '../Icons/CustomIcons';
+import Pagination from '../Pagination/Pagination';
 
 interface Column<T = unknown> {
   Header: string;
@@ -19,6 +20,12 @@ interface TableProps<T extends TableRowBase> {
   data: T[];
   onActivateClick?: (row: T) => void;
   onDeactivateClick?: (row: T) => void;
+  // 페이지네이션 관련 props
+  page?: number;
+  pageSize?: number;
+  onPageChange?: (page: number) => void;
+  onPageSizeChange?: (size: number) => void;
+  showPagination?: boolean;
 }
 
 const Table = <T extends TableRowBase>({
@@ -26,6 +33,11 @@ const Table = <T extends TableRowBase>({
   data,
   onActivateClick,
   onDeactivateClick,
+  page = 1,
+  pageSize = 10,
+  onPageChange,
+  onPageSizeChange,
+  showPagination = false,
 }: TableProps<T>) => {
   const handleActivate = (row: T) => {
     onActivateClick?.(row);
@@ -34,74 +46,111 @@ const Table = <T extends TableRowBase>({
     onDeactivateClick?.(row);
   };
 
+  // 페이지네이션을 위한 데이터 슬라이싱
+  const totalPages = Math.ceil(data.length / pageSize);
+  const startIndex = (page - 1) * pageSize;
+  const endIndex = startIndex + pageSize;
+  const paginatedData = data.slice(startIndex, endIndex);
+
   return (
-    <div className="overflow-x-auto w-full">
-      <table className="min-w-full border-separate border-spacing-0">
-        <thead>
-          <tr className="bg-gray-100 text-gray-700 text-sm">
-            {columns.map((col) => (
-              <th
-                key={String(col.accessor)}
-                className={
-                  `px-4 py-3 font-semibold border-b border-gray-200 whitespace-nowrap ` +
-                  (col.accessor === 'actions' ? 'text-center' : 'text-left')
-                }
-              >
-                {col.Header}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data.length === 0 ? (
-            <tr>
-              <td colSpan={columns.length} className="text-center py-8 text-gray-400">
-                데이터가 없습니다.
-              </td>
+    <div className="space-y-4">
+      <div className="overflow-x-auto w-full">
+        <table className="min-w-full border-separate border-spacing-0">
+          <thead>
+            <tr className="bg-gray-100 text-gray-700 text-sm">
+              {columns.map((col) => (
+                <th
+                  key={String(col.accessor)}
+                  className={
+                    `px-4 py-3 font-semibold border-b border-gray-200 whitespace-nowrap ` +
+                    (col.accessor === 'actions' ? 'text-center' : 'text-left')
+                  }
+                >
+                  {col.Header}
+                </th>
+              ))}
             </tr>
-          ) : (
-            data.map((row, i) => (
-              <tr
-                key={row.id ?? i}
-                className="border-b border-gray-100 hover:bg-gray-50 transition-colors"
-              >
-                {columns.map((col) => (
-                  <td
-                    key={String(col.accessor)}
-                    className={
-                      `px-4 py-2 text-sm text-gray-900 whitespace-nowrap` +
-                      (col.accessor === 'actions' ? ' text-center align-middle' : '')
-                    }
-                  >
-                    {col.accessor === 'actions' ? (
-                      <div className="flex justify-center items-center gap-3 min-h-[40px]">
-                        <button
-                          type="button"
-                          aria-label="비활성화"
-                          className="w-7 h-7 flex items-center justify-center rounded-full p-0 hover:bg-red-100 transition-colors text-red-500"
-                          onClick={() => handleDeactivate(row)}
-                        >
-                          {row.actions?.deactivateIcon ?? <CircleMinusIcon className="w-5 h-5" />}
-                        </button>
-                        <button
-                          type="button"
-                          aria-label="활성화"
-                          className="w-7 h-7 flex items-center justify-center rounded-full p-0 hover:bg-green-100 transition-colors text-green-500"
-                          onClick={() => handleActivate(row)}
-                        >
-                          {row.actions?.activateIcon ?? <ReturnIcon className="w-5 h-5" />}
-                        </button>
-                      </div>
-                    ) : (
-                      String(row[col.accessor as keyof T] ?? '')
-                    )}
-                  </td>
-                ))}
+          </thead>
+          <tbody>
+            {paginatedData.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="text-center py-8 text-gray-400">
+                  데이터가 없습니다.
+                </td>
               </tr>
-            ))
+            ) : (
+              paginatedData.map((row, i) => (
+                <tr
+                  key={row.id ?? i}
+                  className="border-b border-gray-100 hover:bg-gray-50 transition-colors"
+                >
+                  {columns.map((col) => (
+                    <td
+                      key={String(col.accessor)}
+                      className={
+                        `px-4 py-2 text-sm text-gray-900 whitespace-nowrap` +
+                        (col.accessor === 'actions' ? ' text-center align-middle' : '')
+                      }
+                    >
+                      {col.accessor === 'actions' ? (
+                        <div className="flex justify-center items-center gap-3 min-h-[40px]">
+                          <button
+                            type="button"
+                            aria-label="비활성화"
+                            className="w-7 h-7 flex items-center justify-center rounded-full p-0 hover:bg-red-100 transition-colors text-red-500"
+                            onClick={() => handleDeactivate(row)}
+                          >
+                            {row.actions?.deactivateIcon ?? <CircleMinusIcon className="w-5 h-5" />}
+                          </button>
+                          <button
+                            type="button"
+                            aria-label="활성화"
+                            className="w-7 h-7 flex items-center justify-center rounded-full p-0 hover:bg-green-100 transition-colors text-green-500"
+                            onClick={() => handleActivate(row)}
+                          >
+                            {row.actions?.activateIcon ?? <ReturnIcon className="w-5 h-5" />}
+                          </button>
+                        </div>
+                      ) : (
+                        String(row[col.accessor as keyof T] ?? '')
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 페이지네이션 */}
+      {showPagination && data.length > 0 && onPageChange && (
+        <div className="flex items-center justify-between">
+          {/* 페이지 크기 선택 */}
+          {onPageSizeChange && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600">페이지당 행 수:</span>
+              <select
+                value={pageSize}
+                onChange={(e) => onPageSizeChange(Number(e.target.value))}
+                className="px-2 py-1 border border-gray-300 rounded text-sm"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
           )}
-        </tbody>
-      </table>
+
+          {/* 페이지네이션 컴포넌트 */}
+          <Pagination page={page} total={totalPages} onChange={onPageChange} className="flex-1" />
+
+          {/* 데이터 정보 */}
+          <div className="text-sm text-gray-600">
+            {startIndex + 1}-{Math.min(endIndex, data.length)} / {data.length}개
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #257 
### 🔎 작업 내용

- [x] Table 컴포넌트에 페이지네이션 기능 통합
- [x] 페이지네이션 API 단순화 (내부 상태 관리로 변경)
- [x] UserTable 컴포넌트 페이지네이션 적용
- [x] Table 스토리북 스토리 단순화
- [x] Pagination 컴포넌트 개선 (페이지가 한개여도 표시)
### 📸 스크린샷 (선택)
<img width="1314" height="413" alt="image" src="https://github.com/user-attachments/assets/01876f0b-7c5f-460e-960e-737ab8431e47" />
<img width="1593" height="686" alt="image" src="https://github.com/user-attachments/assets/c3d8c4d2-0bd8-4085-981a-477cb1b46011" />

### 📢 전달사항
#### 주요 변경사항:
1. **Table 컴포넌트 API 단순화**
   - 기존: `page`, `pageSize`, `onPageChange`, `onPageSizeChange` props 필요
   - 개선: `showPagination={true}` 하나만 추가하면 자동으로 페이지네이션 작동

2. **내부 상태 관리 도입**
   - Table 컴포넌트 내부에서 페이지네이션 상태 자동 관리합니다
   - 페이지 크기 변경 시 자동으로 첫 페이지로 이동합니다

3. **사용법 개선**
   ```tsx
   // Before (복잡함)
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   <Table
     showPagination={true}
     page={page}
     pageSize={pageSize}
     onPageChange={setPage}
     onPageSizeChange={setPageSize}
   />

   // After (간단함)
   <Table showPagination={true} />
   ```

4. **Pagination 컴포넌트 개선**
   - 1페이지일 때도 페이지네이션 표시 (버튼들은 비활성화)
   - 더 나은 사용자 경험 제공

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 테이블 컴포넌트에 페이지네이션(페이지 이동) 기능이 추가되었습니다.
  * 페이지 크기(10, 20, 50개씩 보기) 선택 및 현재 행 범위 표시가 지원됩니다.

* **버그 수정**
  * 데이터가 한 페이지 이하일 때도 페이지네이션이 정상적으로 표시됩니다.

* **문서화**
  * 다양한 데이터셋 크기와 페이지네이션을 시연하는 스토리북 예제가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->