### PR TITLE
UF-263 테이블 공통 컴포넌트로 리팩토링

### DIFF
--- a/src/app/admin/banned-words/page.tsx
+++ b/src/app/admin/banned-words/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Header from '@/shared/ui/Header/Header';
 import Sidebar from '@/shared/ui/Sidebar/Sidebar';
 import { Table } from '@/shared/ui/Table/Table';

--- a/src/app/admin/banned-words/page.tsx
+++ b/src/app/admin/banned-words/page.tsx
@@ -1,7 +1,29 @@
 import Header from '@/shared/ui/Header/Header';
 import Sidebar from '@/shared/ui/Sidebar/Sidebar';
+import { Table } from '@/shared/ui/Table/Table';
 
 export default function AdminBannedWordsPage() {
+  const bannedWordsData = [
+    { id: 1, word: '욕설1', date: '2024-01-01' },
+    { id: 2, word: '욕설2', date: '2024-01-02' },
+    { id: 3, word: '스팸', date: '2024-01-03' },
+  ];
+
+  const columns = [
+    { Header: '금칙어', accessor: 'word' as const },
+    { Header: '등록일', accessor: 'date' as const },
+    {
+      Header: '관리',
+      accessor: 'actions' as const,
+      render: () => (
+        <div className="flex gap-2">
+          <button className="text-blue-600 hover:text-blue-900 mr-3">수정</button>
+          <button className="text-red-600 hover:text-red-900">삭제</button>
+        </div>
+      ),
+    },
+  ];
+
   return (
     <div className="flex h-screen bg-gray-50">
       <div className="hidden lg:block">
@@ -32,35 +54,7 @@ export default function AdminBannedWordsPage() {
 
             {/* 금칙어 목록 */}
             <div className="bg-white rounded-lg shadow overflow-hidden">
-              <table className="min-w-full">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      금칙어
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      등록일
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      관리
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {['욕설1', '욕설2', '스팸'].map((word, i) => (
-                    <tr key={i}>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{word}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        2024-01-{(i + 1).toString().padStart(2, '0')}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        <button className="text-blue-600 hover:text-blue-900 mr-3">수정</button>
-                        <button className="text-red-600 hover:text-red-900">삭제</button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              <Table columns={columns} data={bannedWordsData} />
             </div>
           </div>
         </main>

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Header from '@/shared/ui/Header/Header';
 import Sidebar from '@/shared/ui/Sidebar/Sidebar';
 import { Table } from '@/shared/ui/Table/Table';

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -1,7 +1,42 @@
 import Header from '@/shared/ui/Header/Header';
 import Sidebar from '@/shared/ui/Sidebar/Sidebar';
+import { Table } from '@/shared/ui/Table/Table';
 
 export default function AdminPostsPage() {
+  const postsData = [
+    { id: 1, title: '게시물 제목 1', author: '사용자1', date: '2024-01-01', status: '활성' },
+    { id: 2, title: '게시물 제목 2', author: '사용자2', date: '2024-01-02', status: '활성' },
+    { id: 3, title: '게시물 제목 3', author: '사용자3', date: '2024-01-03', status: '활성' },
+    { id: 4, title: '게시물 제목 4', author: '사용자4', date: '2024-01-04', status: '활성' },
+    { id: 5, title: '게시물 제목 5', author: '사용자5', date: '2024-01-05', status: '활성' },
+  ];
+
+  const columns = [
+    { Header: 'ID', accessor: 'id' as const },
+    { Header: '제목', accessor: 'title' as const },
+    { Header: '작성자', accessor: 'author' as const },
+    { Header: '작성일', accessor: 'date' as const },
+    {
+      Header: '상태',
+      accessor: 'status' as const,
+      render: (value: unknown) => (
+        <span className="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">
+          {String(value)}
+        </span>
+      ),
+    },
+    {
+      Header: '관리',
+      accessor: 'actions' as const,
+      render: () => (
+        <div className="flex gap-2">
+          <button className="text-blue-600 hover:text-blue-900 mr-3">수정</button>
+          <button className="text-red-600 hover:text-red-900">삭제</button>
+        </div>
+      ),
+    },
+  ];
+
   return (
     <div className="flex h-screen bg-gray-50">
       <div className="hidden lg:block">
@@ -34,55 +69,7 @@ export default function AdminPostsPage() {
 
             {/* 게시물 목록 */}
             <div className="bg-white rounded-lg shadow overflow-hidden">
-              <table className="min-w-full">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      ID
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      제목
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      작성자
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      작성일
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      상태
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      관리
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {[1, 2, 3, 4, 5].map((i) => (
-                    <tr key={i}>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{i}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                        게시물 제목 {i}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        사용자{i}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        2024-01-{i.toString().padStart(2, '0')}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <span className="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">
-                          활성
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        <button className="text-blue-600 hover:text-blue-900 mr-3">수정</button>
-                        <button className="text-red-600 hover:text-red-900">삭제</button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              <Table columns={columns} data={postsData} />
             </div>
           </div>
         </main>

--- a/src/app/admin/posts/reported/page.tsx
+++ b/src/app/admin/posts/reported/page.tsx
@@ -1,7 +1,61 @@
 import Header from '@/shared/ui/Header/Header';
 import Sidebar from '@/shared/ui/Sidebar/Sidebar';
+import { Table } from '@/shared/ui/Table/Table';
 
 export default function AdminReportedPostsPage() {
+  const reportedPostsData = [
+    {
+      id: 1,
+      postId: 'POST_1',
+      reason: '욕설/혐오 표현',
+      reporter: '신고자1',
+      date: '2024-01-01',
+      status: '대기중',
+    },
+    {
+      id: 2,
+      postId: 'POST_2',
+      reason: '욕설/혐오 표현',
+      reporter: '신고자2',
+      date: '2024-01-02',
+      status: '대기중',
+    },
+    {
+      id: 3,
+      postId: 'POST_3',
+      reason: '욕설/혐오 표현',
+      reporter: '신고자3',
+      date: '2024-01-03',
+      status: '대기중',
+    },
+  ];
+
+  const columns = [
+    { Header: '게시물 ID', accessor: 'postId' as const },
+    { Header: '신고 사유', accessor: 'reason' as const },
+    { Header: '신고자', accessor: 'reporter' as const },
+    { Header: '신고일', accessor: 'date' as const },
+    {
+      Header: '처리 상태',
+      accessor: 'status' as const,
+      render: (value: unknown) => (
+        <span className="px-2 py-1 text-xs font-semibold rounded-full bg-yellow-100 text-yellow-800">
+          {String(value)}
+        </span>
+      ),
+    },
+    {
+      Header: '관리',
+      accessor: 'actions' as const,
+      render: () => (
+        <div className="flex gap-2">
+          <button className="text-green-600 hover:text-green-900 mr-3">승인</button>
+          <button className="text-red-600 hover:text-red-900">거부</button>
+        </div>
+      ),
+    },
+  ];
+
   return (
     <div className="flex h-screen bg-gray-50">
       <div className="hidden lg:block">
@@ -16,57 +70,7 @@ export default function AdminReportedPostsPage() {
             <h1 className="text-2xl font-bold text-gray-900 mb-6">신고된 게시물</h1>
 
             <div className="bg-white rounded-lg shadow overflow-hidden">
-              <table className="min-w-full">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      게시물 ID
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      신고 사유
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      신고자
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      신고일
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      처리 상태
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      관리
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {[1, 2, 3].map((i) => (
-                    <tr key={i}>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                        POST_{i}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                        욕설/혐오 표현
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        신고자{i}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        2024-01-{i.toString().padStart(2, '0')}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <span className="px-2 py-1 text-xs font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                          대기중
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        <button className="text-green-600 hover:text-green-900 mr-3">승인</button>
-                        <button className="text-red-600 hover:text-red-900">거부</button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              <Table columns={columns} data={reportedPostsData} />
             </div>
           </div>
         </main>

--- a/src/app/admin/posts/reported/page.tsx
+++ b/src/app/admin/posts/reported/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Header from '@/shared/ui/Header/Header';
 import Sidebar from '@/shared/ui/Sidebar/Sidebar';
 import { Table } from '@/shared/ui/Table/Table';

--- a/src/app/admin/user/inactive/page.tsx
+++ b/src/app/admin/user/inactive/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Header from '@/shared/ui/Header/Header';
 import Sidebar from '@/shared/ui/Sidebar/Sidebar';
 import { Table } from '@/shared/ui/Table/Table';

--- a/src/app/admin/user/inactive/page.tsx
+++ b/src/app/admin/user/inactive/page.tsx
@@ -1,7 +1,113 @@
 import Header from '@/shared/ui/Header/Header';
 import Sidebar from '@/shared/ui/Sidebar/Sidebar';
+import { Table } from '@/shared/ui/Table/Table';
 
 export default function AdminInactiveUsersPage() {
+  const inactiveUsersData = [
+    {
+      id: 1,
+      nickname: 'blocked_user1',
+      email: 'blocked1@example.com',
+      reason: '신고 누적',
+      date: '2024-01-15',
+      reports: 15,
+    },
+    {
+      id: 2,
+      nickname: 'suspended_user2',
+      email: 'suspended2@example.com',
+      reason: '약관 위반',
+      date: '2024-01-14',
+      reports: 8,
+    },
+    {
+      id: 3,
+      nickname: 'banned_user3',
+      email: 'banned3@example.com',
+      reason: '관리자 조치',
+      date: '2024-01-13',
+      reports: 23,
+    },
+    {
+      id: 4,
+      nickname: 'inactive_user4',
+      email: 'inactive4@example.com',
+      reason: '계정 정지',
+      date: '2024-01-12',
+      reports: 5,
+    },
+    {
+      id: 5,
+      nickname: 'frozen_user5',
+      email: 'frozen5@example.com',
+      reason: '신고 누적',
+      date: '2024-01-11',
+      reports: 12,
+    },
+  ];
+
+  const columns = [
+    { Header: 'ID', accessor: 'id' as const },
+    { Header: '닉네임', accessor: 'nickname' as const },
+    { Header: '이메일', accessor: 'email' as const },
+    {
+      Header: '비활성화 사유',
+      accessor: 'reason' as const,
+      render: (value: unknown) => {
+        const getBadgeStyle = (reason: string) => {
+          switch (reason) {
+            case '신고 누적':
+              return 'bg-red-100 text-red-800';
+            case '약관 위반':
+              return 'bg-orange-100 text-orange-800';
+            case '관리자 조치':
+              return 'bg-purple-100 text-purple-800';
+            default:
+              return 'bg-gray-100 text-gray-800';
+          }
+        };
+        return (
+          <span
+            className={`px-2 py-1 text-xs font-semibold rounded-full ${getBadgeStyle(String(value))}`}
+          >
+            {String(value)}
+          </span>
+        );
+      },
+    },
+    { Header: '비활성화 일시', accessor: 'date' as const },
+    {
+      Header: '신고 횟수',
+      accessor: 'reports' as const,
+      render: (value: unknown) => (
+        <span
+          className={`font-medium ${
+            Number(value) >= 15
+              ? 'text-red-600'
+              : Number(value) >= 10
+                ? 'text-orange-600'
+                : 'text-gray-600'
+          }`}
+        >
+          {Number(value)}회
+        </span>
+      ),
+    },
+    {
+      Header: '관리',
+      accessor: 'actions' as const,
+      render: () => (
+        <div className="flex gap-2">
+          <button className="text-green-600 hover:text-green-900 text-sm font-medium">
+            활성화
+          </button>
+          <button className="text-blue-600 hover:text-blue-900 text-sm font-medium">상세</button>
+          <button className="text-red-600 hover:text-red-900 text-sm font-medium">영구삭제</button>
+        </div>
+      ),
+    },
+  ];
+
   return (
     <div className="flex h-screen bg-gray-50">
       <div className="hidden lg:block">
@@ -64,128 +170,7 @@ export default function AdminInactiveUsersPage() {
               <div className="px-6 py-4 border-b border-gray-200">
                 <h3 className="text-lg font-medium text-gray-900">비활성화 사용자 목록</h3>
               </div>
-
-              <table className="min-w-full">
-                <thead className="bg-red-50">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      ID
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      닉네임
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      이메일
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      비활성화 사유
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      비활성화 일시
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      신고 횟수
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                      관리
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {[
-                    {
-                      id: 1,
-                      nickname: 'blocked_user1',
-                      email: 'blocked1@example.com',
-                      reason: '신고 누적',
-                      date: '2024-01-15',
-                      reports: 15,
-                    },
-                    {
-                      id: 2,
-                      nickname: 'suspended_user2',
-                      email: 'suspended2@example.com',
-                      reason: '약관 위반',
-                      date: '2024-01-14',
-                      reports: 8,
-                    },
-                    {
-                      id: 3,
-                      nickname: 'banned_user3',
-                      email: 'banned3@example.com',
-                      reason: '관리자 조치',
-                      date: '2024-01-13',
-                      reports: 23,
-                    },
-                    {
-                      id: 4,
-                      nickname: 'inactive_user4',
-                      email: 'inactive4@example.com',
-                      reason: '계정 정지',
-                      date: '2024-01-12',
-                      reports: 5,
-                    },
-                    {
-                      id: 5,
-                      nickname: 'frozen_user5',
-                      email: 'frozen5@example.com',
-                      reason: '신고 누적',
-                      date: '2024-01-11',
-                      reports: 12,
-                    },
-                  ].map((user) => (
-                    <tr key={user.id} className="hover:bg-gray-50">
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                        {user.id}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                        {user.nickname}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {user.email}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <span
-                          className={`px-2 py-1 text-xs font-semibold rounded-full ${
-                            user.reason === '신고 누적'
-                              ? 'bg-red-100 text-red-800'
-                              : user.reason === '약관 위반'
-                                ? 'bg-orange-100 text-orange-800'
-                                : user.reason === '관리자 조치'
-                                  ? 'bg-purple-100 text-purple-800'
-                                  : 'bg-gray-100 text-gray-800'
-                          }`}
-                        >
-                          {user.reason}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {user.date}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                        <span
-                          className={`font-medium ${user.reports >= 15 ? 'text-red-600' : user.reports >= 10 ? 'text-orange-600' : 'text-gray-600'}`}
-                        >
-                          {user.reports}회
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        <div className="flex gap-2">
-                          <button className="text-green-600 hover:text-green-900 text-sm font-medium">
-                            활성화
-                          </button>
-                          <button className="text-blue-600 hover:text-blue-900 text-sm font-medium">
-                            상세
-                          </button>
-                          <button className="text-red-600 hover:text-red-900 text-sm font-medium">
-                            영구삭제
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              <Table columns={columns} data={inactiveUsersData} />
             </div>
 
             {/* 페이지네이션 */}

--- a/src/shared/ui/Table/Table.tsx
+++ b/src/shared/ui/Table/Table.tsx
@@ -8,6 +8,7 @@ import Pagination from '../Pagination/Pagination';
 interface Column<T = unknown> {
   Header: string;
   accessor: keyof T | string;
+  render?: (value: unknown, row: T) => React.ReactNode;
 }
 
 interface TableRowBase {
@@ -108,6 +109,8 @@ const Table = <T extends TableRowBase>({
                             {row.actions?.activateIcon ?? <ReturnIcon className="w-5 h-5" />}
                           </button>
                         </div>
+                      ) : col.render ? (
+                        col.render(row[col.accessor as keyof T], row)
                       ) : (
                         String(row[col.accessor as keyof T] ?? '')
                       )}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #272 

### 🔎 작업 내용

- [x] 각 관리자 페이지의 하드코딩된 HTML 테이블을 공통 Table 컴포넌트로 리팩토링
- [x] Table 컴포넌트에 render prop 기능 추가하여 커스텀 셀 렌더링 지원

### 📸 스크린샷 (선택)

### 📢 전달사항

리팩토링 대상 페이지:
- /admin/banned-words - 금칙어 관리 테이블
- /admin/posts - 게시물 관리 테이블
- /admin/user/inactive - 비활성 사용자 테이블
- /admin/posts/reported - 신고된 게시물 테이블
주요 변경사항:
- Table 컴포넌트 개선: render prop 추가로 커스텀 셀 렌더링 지원
- 타입 안정성: render 함수의 value 파라미터 타입을 unknown으로 변경하여 ESLint 에러 해결
- 일관성: 모든 관리자 페이지에서 동일한 Table 컴포넌트 사용으로 코드 중복 제거
기술적 세부사항:
- 각 페이지별로 columns 배열과 data 배열을 정의하여 Table 컴포넌트에 전달
- 상태 표시, 액션 버튼 등 복잡한 셀 내용은 render 함수로 구현
- TypeScript 타입 안정성 확보를 위해 value: unknown 타입 사용>

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리 페이지(금지어, 게시글, 신고된 게시글, 비활성 사용자)에 재사용 가능한 테이블 컴포넌트를 도입하여 테이블 UI를 개선했습니다.
  * 테이블의 각 열에 맞춤 렌더링 기능이 추가되어, 상태 뱃지 및 관리 버튼 등 다양한 UI 요소가 지원됩니다.

* **리팩터링**
  * 기존의 하드코딩된 테이블 마크업을 구조화된 데이터와 컬럼 정의 방식으로 변경하여 유지보수성과 확장성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->