### PR TITLE
UF-275 develop 브랜치에서도 개인 레포 자동 배포 설정 추가

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,7 +48,7 @@ jobs:
     name: Deploy to Personal Repo
     runs-on: ubuntu-latest
     needs: build-check
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && github.event_name == 'push'
 
     steps:
       - name: Checkout
@@ -72,31 +72,33 @@ jobs:
 
       - name: Create deployment package
         run: |
-          mkdir -p deploy-output
-          cp -R .next/ deploy-output/
-          cp -R public/ deploy-output/
-          cp package*.json deploy-output/
-          cp next.config.ts deploy-output/
-          cp vercel.json deploy-output/ 2>/dev/null || echo "vercel.json not found, skipping"
+          mkdir -p output
+          # Next.js 빌드 결과물 복사
+          cp -R .next/ output/
+          cp -R public/ output/
+          cp package*.json output/
+          cp next.config.ts output/
+          cp vercel.json output/ 2>/dev/null || echo "vercel.json not found, skipping"
 
-          echo "# UFO-Fi Frontend" > deploy-output/README.md
-          echo "Deployed from: ${{ github.repository }}" >> deploy-output/README.md
-          echo "Commit: ${{ github.sha }}" >> deploy-output/README.md
-          echo "Build Date: $(date)" >> deploy-output/README.md
+          # README 생성
+          echo "# UFO-Fi Frontend" > output/README.md
+          echo "Deployed from: ${{ github.repository }}" >> output/README.md
+          echo "Commit: ${{ github.sha }}" >> output/README.md
+          echo "Build Date: $(date)" >> output/README.md
 
       - name: Push to personal deployment repository
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.UFOFI_GITHUB_KEY }}
         with:
-          source-directory: 'deploy-output'
-          destination-github-username: ${{ secrets.UFOFI_USERNAME }}
-          destination-repository-name: 'UFO-Fi-FE-Deploy'
+          source-directory: 'output'
+          destination-github-username: 'abyss-s'
+          destination-repository-name: 'UFO-Fi-FE'
           user-email: ${{ secrets.UFOFI_ACCOUNT_EMAIL }}
           commit-message: '🚀 Deploy: ${{ github.event.head_commit.message }}'
           target-branch: main
 
-      - name: Comment on PR with deployment info
+      - name: Comment on commit with deployment info
         if: github.event_name == 'push'
         uses: actions/github-script@v7
         with:
@@ -109,7 +111,8 @@ jobs:
 
             Build successful
             Deployed to: https://github.com/${{ secrets.UFOFI_USERNAME }}/UFO-Fi-FE
-            Vercel URL: https://ufo-fi-fe.vercel.app (if connected)
+            Vercel URL: https://www.ufo-fi.store
 
-            Commit: \`${context.sha.substring(0, 7)}\``
+            Commit: \`${context.sha.substring(0, 7)}\`
+            Build Date: ${new Date().toISOString()}`
             })

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -77,7 +77,7 @@ jobs:
           cp -R .next/ output/
           cp -R public/ output/
           cp package*.json output/
-          cp next.config.ts output/
+          cp next.config.ts output/ 2>/dev/null || echo "next.config.ts not found, skipping"
           cp vercel.json output/ 2>/dev/null || echo "vercel.json not found, skipping"
 
           # README 생성
@@ -92,8 +92,8 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.UFOFI_GITHUB_KEY }}
         with:
           source-directory: 'output'
-          destination-github-username: 'abyss-s'
-          destination-repository-name: 'UFO-Fi-FE'
+          destination-github-username: ${{ secrets.DEPLOY_GH_USERNAME }}
+          destination-repository-name: ${{ secrets.DEPLOY_GH_REPO }}
           user-email: ${{ secrets.UFOFI_ACCOUNT_EMAIL }}
           commit-message: '🚀 Deploy: ${{ github.event.head_commit.message }}'
           target-branch: main


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #288 

### 🔎 작업 내용

- [x] develop 브랜치에서도 개인 레포 자동 배포 설정 추가되도록 수정

### 📸 스크린샷 (선택)

### 📢 전달사항
핫픽스라 머지합니다~
<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 배포 워크플로우가 이제 `main`과 `develop` 브랜치 모두에서 실행됩니다.
  * 배포 산출물 디렉토리명이 `deploy-output`에서 `output`으로 변경되었습니다.
  * 배포 커밋에 남기는 코멘트 내용이 업데이트되어, Vercel URL이 `https://www.ufo-fi.store`로 변경되고 빌드 일시가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->