### PR TITLE
UF-279 로그아웃 API 연동

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -14,6 +14,7 @@ export { editProfileAPI } from './services/mypage/editProfile';
 export { profileAPI } from './services/profile/profile';
 export { bannedWordsAPI } from './services/admin/bannedWords';
 export { reportAPI } from './services/report/report';
+export { logoutAPI } from './services/auth/logout';
 
 // 타입들 re-export
 export type * from './types';

--- a/src/api/services/auth/logout.ts
+++ b/src/api/services/auth/logout.ts
@@ -1,0 +1,9 @@
+import { apiRequest } from '@/api/client/axios';
+import { SetLogoutResponse } from '@/api/types';
+
+export const logoutAPI = {
+  async setLogout(): Promise<SetLogoutResponse> {
+    const response = await apiRequest.get<SetLogoutResponse>('/v1/logout');
+    return response.data;
+  },
+};

--- a/src/api/types/auth.ts
+++ b/src/api/types/auth.ts
@@ -1,3 +1,4 @@
+import { SuccessApiResponse } from './api';
 import { Carrier } from './carrier';
 import type { Plan } from './plan';
 
@@ -32,3 +33,10 @@ export interface GetPlansResponse {
     plansReadRes: Plan[];
   };
 }
+
+export interface SetLogoutContent {
+  statusCode: number;
+  message: string;
+}
+
+export type SetLogoutResponse = SuccessApiResponse<SetLogoutContent>;

--- a/src/app/login/success/page.tsx
+++ b/src/app/login/success/page.tsx
@@ -39,8 +39,7 @@ const SuccessPage = () => {
         }
 
         setPhoneNumber(response.content.phoneNumber);
-      } catch (err) {
-        console.log('회원 정보 요청 실패: ', err);
+      } catch {
         setToast('회원 정보를 불러올 수 없습니다.', 'error');
         router.push('/login');
       }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -4,11 +4,13 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
+import { logoutAPI } from '@/api';
 import { LogoutModal } from '@/features/mypage/components';
 import MenuSection from '@/features/mypage/components/MenuSection';
 import SignalCard from '@/features/mypage/components/SignalCard';
 import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
 import { Icon } from '@/shared';
+import { useToastStore } from '@/stores/useToastStore';
 import { useTradeTabStore } from '@/stores/useTradeTabStore';
 
 export default function MyPage() {
@@ -16,6 +18,7 @@ export default function MyPage() {
   const { setTab } = useTradeTabStore();
   const [isOpen, setIsOpen] = useState(false);
   const { data: mypageInfo, error, isLoading } = useMyInfo();
+  const { setToast } = useToastStore();
 
   const navigateToSalesHistory = () => {
     setTab('sell');
@@ -25,10 +28,14 @@ export default function MyPage() {
     setTab('purchase');
     router.push('/mypage/trade');
   };
-  const handleLogout = () => {
-    // TODO: 로그아웃 로직 추가 필요
-    router.push('/login');
-    toast.success('로그아웃 되었습니다!');
+  const handleLogout = async () => {
+    try {
+      await logoutAPI.setLogout();
+      setToast('로그아웃 되었습니다!', 'success');
+      router.push('/login');
+    } catch {
+      toast.error('로그아웃에 실패했습니다.');
+    }
   };
   const navigateToTerms = () => router.push('/mypage/privacy');
   const navigateToFollow = () => router.push('/mypage/follow');

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -91,7 +91,7 @@ export default function MyPage() {
           <Icon
             name="Bell"
             size={24}
-            className="mx-autotransition-all duration-300 group-hover:scale-110 text-white"
+            className="mx-auto transition-all duration-300 group-hover:scale-110 text-white"
           />
           <p className="mt-2 caption-12-regular">알림 설정</p>
         </div>

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 type StatusProps = 'success' | 'info' | 'warning' | 'error' | 'message' | 'loading';
 
@@ -11,17 +10,10 @@ interface ToastStore {
   clearToast: () => void;
 }
 
-export const useToastStore = create<ToastStore>()(
-  persist(
-    (set) => ({
-      message: null,
-      status: 'success',
-      hasShown: true,
-      setToast: (msg, stat = 'message') => set({ message: msg, status: stat, hasShown: false }),
-      clearToast: () => set({ message: null, status: 'success', hasShown: true }),
-    }),
-    {
-      name: 'toast-store',
-    },
-  ),
-);
+export const useToastStore = create<ToastStore>()((set) => ({
+  message: null,
+  status: 'success',
+  hasShown: true,
+  setToast: (msg, stat = 'message') => set({ message: msg, status: stat, hasShown: false }),
+  clearToast: () => set({ message: null, status: 'success', hasShown: true }),
+}));


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #303 

### 🔎 작업 내용

- [x] 로그아웃 API 연동
- [x] useToastStore Persist 제거

### 📸 스크린샷 (선택)
<img width="766" height="906" alt="image" src="https://github.com/user-attachments/assets/3f50d8ce-6ed1-451c-9495-b6532cf21bbe" />

### 📢 전달사항
useEffect()는 React Strict Mode 개발 환경에서 자동으로 두 번 실행되어, 개발 환경이라면 toast()가 두 번 실행됩니다.

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 로그아웃 API 연동이 추가되어, 마이페이지에서 실제 로그아웃 처리가 가능해졌습니다.

* **버그 수정**
  * 로그인 성공 페이지에서 사용자 정보 요청 실패 시 더 이상 콘솔에 에러가 출력되지 않고, 토스트 알림과 함께 로그인 페이지로 이동합니다.

* **리팩터**
  * 토스트 스토어의 상태가 세션이나 새로고침 시 더 이상 유지되지 않도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->