### PR TITLE
UF-295 마이페이지 UI/UX 개선 - 업적 시스템 연결 및 고객 지원 메뉴 확장

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -41,6 +41,7 @@ export default function MyPage() {
   const navigateToPrivacy = () => router.push('/mypage/privacy');
   const navigateToFollow = () => router.push('/mypage/follow');
   const navigateToNotification = () => router.push('/mypage/notification');
+  const navigateToAchievement = () => router.push('/mypage/achievement');
 
   const transactionItems = [
     { label: '판매 내역', onClick: navigateToSalesHistory },
@@ -81,13 +82,13 @@ export default function MyPage() {
           />
           <p className="mt-2 caption-12-regular">팔로우 목록</p>
         </div>
-        <div className="group hover:cursor-pointer">
+        <div className="group hover:cursor-pointer" onClick={navigateToAchievement}>
           <Icon
-            name="Eye"
+            name="Star"
             size={24}
             className="mx-auto transition-all duration-300 group-hover:scale-110 text-white"
           />
-          <p className="mt-2 caption-12-regular">최근 본 글</p>
+          <p className="mt-2 caption-12-regular">업적 목록</p>
         </div>
         <div className="group hover:cursor-pointer" onClick={navigateToNotification}>
           <Icon

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -37,7 +37,8 @@ export default function MyPage() {
       toast.error('로그아웃에 실패했습니다.');
     }
   };
-  const navigateToTerms = () => router.push('/mypage/privacy');
+  const navigateToTerms = () => router.push('/mypage/service');
+  const navigateToPrivacy = () => router.push('/mypage/privacy');
   const navigateToFollow = () => router.push('/mypage/follow');
   const navigateToNotification = () => router.push('/mypage/notification');
 
@@ -49,6 +50,7 @@ export default function MyPage() {
   const supportItems = [
     { label: '로그아웃', onClick: () => setIsOpen(true) },
     { label: '이용 약관', onClick: navigateToTerms },
+    { label: '개인정보처리방침', onClick: navigateToPrivacy },
   ];
 
   if (isLoading) {


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #324 

### 🔎 작업 내용

- [x] 마이페이지 "최근 본 글"을 "업적 목록"으로 변경
- [x] 업적 목록 아이콘을 Eye에서 Star로 변경
- [x] 업적 목록 클릭 시  /mypage/achievement페이지로 라우팅 연결
- [x] 고객 지원 섹션에 개인정보처리방침 추가
- [x] 이용약관 링크를 올바른 페이지로 수정

### 📸 스크린샷 (선택)
<img width="407" height="508" alt="image" src="https://github.com/user-attachments/assets/60630fe3-4253-4ae2-8579-a41cc1502857" />

### 📢 전달사항
- 마이페이지 메뉴 구조를 개선하여 사용자 경혐을 향상시켰습니다.
- 고객 지원 메뉴를 확장하여 이용약관과 개인정보처리방침에 대한 접근성을 개선했습니다.

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지에 "업적 목록" 메뉴가 추가되어 클릭 시 업적 페이지로 이동할 수 있습니다.
  * "개인정보처리방침" 메뉴가 지원 메뉴에 새롭게 추가되었습니다.

* **기능 개선**
  * "최근 본 글" 메뉴가 "업적 목록"으로 변경되었으며, 아이콘이 "Star"로 바뀌었습니다.
  * 이용약관 및 개인정보처리방침 메뉴의 이동 경로가 명확하게 분리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->