### PR TITLE
UF-296 충전 페이지 패키지 카드 반응형 UI 개선

### DIFF
--- a/src/features/charge/components/ZetChargePackageCard.tsx
+++ b/src/features/charge/components/ZetChargePackageCard.tsx
@@ -30,7 +30,7 @@ export function ZetChargePackageCard({
   };
 
   return (
-    <div className="gradient-card-1 w-[358px] h-[104px] rounded-2xl px-5 py-3 relative">
+    <div className="gradient-card-1 w-full h-[104px] rounded-2xl px-5 py-3 relative">
       <Image
         src={IMAGE_PATHS[`PACKAGE_${id}` as keyof typeof IMAGE_PATHS]}
         alt={`패키지 ${id} 이미지`}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #325 

### 🔎 작업 내용

- [x] 충전 페이지 /charge 및 패키지 카드 컴포넌트 구조 확인
- [x] ZetChargePackageCard 컴포넌트의 고정 너비(w-[358px])를 w-full로 변경
- [x] 부모 그리드/flex container 구조에 맞게 크기 확장 확인
- [x] 반응형 UI 개선으로 다양한 화면 크기에서 일관된 사용자 경험 제공

### 📸 스크린샷 (선택)

### 📢 전달사항
- 충전 페이지의 패키지 선택 컴포넌트가 이제 모든 화면 크기에서 적절히 반응합니다
- 기존 고정 너비(358px)에서 w-full로 변경하여 부모 컨테이너의 전체 너비를 활용합니다
- 모바일, 태블릿, 데스크톱 등 다양한 디바이스에서 일관된 레이아웃을 제공합니다
- 기존의 세로 배치(flex flex-col)와 간격(gap-3)은 유지하여 디자인 일관성을 보장합니다

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * ZetChargePackageCard 컴포넌트의 카드가 고정된 너비에서 부모 컨테이너의 전체 너비를 차지하도록 변경되어, 레이아웃이 더욱 유연하고 반응형으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->