### PR TITLE
UF-313 네비게이션 바가 메인 콘텐츠를 가리는 레이아웃 버그 수정

### DIFF
--- a/src/provider/AppLayoutProvider.tsx
+++ b/src/provider/AppLayoutProvider.tsx
@@ -66,8 +66,9 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
         <main
           className="overflow-y-auto overflow-x-hidden hide-scrollbar relative z-10 sm:px-10.5 px-6 text-white"
           style={{
-            height: `calc(100dvh - ${isNavigationHidden ? '0px' : `${NAV_HEIGHT + BOTTOM_NAV_HEIGHT}px`})`,
-            marginTop: isNavigationHidden ? '0px' : `${NAV_HEIGHT}px`,
+            minHeight: '100dvh',
+            paddingTop: isNavigationHidden ? '0px' : `${NAV_HEIGHT}px`,
+            paddingBottom: isNavigationHidden ? '0px' : `${BOTTOM_NAV_HEIGHT}px`,
             WebkitOverflowScrolling: 'touch',
             overscrollBehavior: 'contain',
           }}

--- a/src/shared/layout/BottomNav/BottomNav.tsx
+++ b/src/shared/layout/BottomNav/BottomNav.tsx
@@ -37,7 +37,7 @@ const BottomNav: React.FC<BottomNavProps> = ({ onTabChange }) => {
   };
 
   return (
-    <footer className="absolute bottom-0 left-0 right-0 h-16 z-30">
+    <footer className="fixed bottom-0 left-1/2 transform -translate-x-1/2 h-16 z-30 w-full min-w-[375px] max-w-[620px]">
       <div className="w-full h-16 bg-primary-700 border-t border-white/10">
         <nav className="flex items-center justify-around h-16 w-full">
           {navItems.map((item) => {

--- a/src/shared/layout/TopNav/TopNav.tsx
+++ b/src/shared/layout/TopNav/TopNav.tsx
@@ -20,8 +20,8 @@ interface TopNavProps {
 const TopNav: React.FC<TopNavProps> = ({ title = 'UFO-Fi', onNotificationClick }) => {
   const { data: myInfo } = useMyInfo();
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
-  const [notifications, setNotifications] = useState<NotificationItem[]>([]); // 추가
-  const [isLoading, setIsLoading] = useState(false); // 추가
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
 
   // 알림 데이터 로드 함수 추가
   const loadNotifications = async () => {
@@ -58,7 +58,7 @@ const TopNav: React.FC<TopNavProps> = ({ title = 'UFO-Fi', onNotificationClick }
   };
 
   return (
-    <header className="absolute top-0 left-0 right-0 h-14 bg-primary-700 z-30 shadow-sm">
+    <header className="fixed top-0 left-1/2 transform -translate-x-1/2 h-14 z-30 w-full min-w-[375px] max-w-[620px] bg-primary-700 shadow-sm">
       <div className="flex items-center justify-between h-full px-4 w-full">
         <div className="flex items-center gap-3">
           {ICON_PATHS?.UFO_LOGO ? (
@@ -78,8 +78,8 @@ const TopNav: React.FC<TopNavProps> = ({ title = 'UFO-Fi', onNotificationClick }
             onToggle={() => setIsNotificationOpen(!isNotificationOpen)}
             onNotificationClick={handleNotificationClick}
             onMarkAllRead={handleMarkAllRead}
-            notifications={notifications} // 추가
-            isLoading={isLoading} // 추가
+            notifications={notifications}
+            isLoading={isLoading}
           />
         )}
       </div>


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #350 

### 🔎 작업 내용

- [x] 네비게이션 바가 메인 콘텐츠를 가리는 레이아웃 버그 수정

### 📸 스크린샷 (선택)
<img width="858" height="613" alt="스크린샷 2025-07-29 오전 1 33 31" src="https://github.com/user-attachments/assets/b8574b6b-d674-4e68-823a-2e727fad6b28" />

### 📢 전달사항
> 이젠 절대 min-h-full을 써주시와요.. 또한 Page.tsx에서 좌우 패딩 설정하시면 안돼요~^^
<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 메인 콘텐츠, 상단 네비게이션, 하단 네비게이션의 레이아웃 및 위치가 개선되어 더 유연하고 일관된 화면 배치를 제공합니다.
  * 상단 및 하단 네비게이션 바가 화면 중앙에 고정되고, 최소/최대 너비가 적용되어 다양한 화면 크기에서 더 보기 좋게 표시됩니다.  
  * 불필요한 주석이 제거되어 코드가 더 깔끔해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->