### PR TITLE
UF-318 앱 레이아웃 프로바이더 버그 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,14 +3,13 @@ import PlanetProgressBar from '@/features/main/components/PlanetProgressBar';
 
 export default function HomePage() {
   return (
-    <div className="flex flex-row justify-center w-full min-h-full">
-      <div className="relative w-full bg-[url(/bg.png)] bg-cover">
-        {/* 궤도 + 위성 + 말풍선 */}
+    <div className="w-full min-h-full flex flex-col">
+      <div className="flex-1 flex items-center justify-center">
         <OrbitWithSatellite />
+      </div>
 
-        <div className="absolute bottom-10 left-1/2 -translate-x-1/2">
-          <PlanetProgressBar />
-        </div>
+      <div className="fixed bottom-32 left-1/2 transform -translate-x-1/2 z-30">
+        <PlanetProgressBar />
       </div>
     </div>
   );

--- a/src/features/main/components/OrbitWithSatellite.tsx
+++ b/src/features/main/components/OrbitWithSatellite.tsx
@@ -112,7 +112,7 @@ export default function OrbitWithSatellite() {
       })}
 
       {/* 중앙 행성 + 외계인 */}
-      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 relative w-auto h-[220px]">
+      <div className="top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 relative w-auto h-[220px]">
         {/* 말풍선 */}
         <div className="absolute top-[-90px] left-1/2 -translate-x-1/2 z-20">
           <SpeechBubble tailDirection="bottom">지구인님, 오늘 거래하실 건가요?</SpeechBubble>

--- a/src/features/main/components/PlanetProgressBar.tsx
+++ b/src/features/main/components/PlanetProgressBar.tsx
@@ -40,9 +40,11 @@ export default function PlanetProgressBar() {
   const completed = planets.filter((p) => p.active).length;
 
   return (
-    <div className="flex flex-col items-center w-full gap-2 px-4">
+    <div className="flex flex-col items-center w-full gap-4 px-4">
       {/* 진행 텍스트 */}
-      <p className="text-white text-sm">{completed}번째 은하까지 탐사 완료...</p>
+      <p className="text-white text-sm pyeongchangpeace-title-2">
+        {completed}번째 은하까지 탐사 완료...
+      </p>
 
       {/* 행성 + 점선 궤도 */}
       <div className="relative flex items-center justify-center w-full">
@@ -66,7 +68,7 @@ export default function PlanetProgressBar() {
 function Planet({ src, active, color }: Planet) {
   return (
     <div
-      className="relative w-12 h-12 rounded-full flex items-center justify-center"
+      className="relative w-10 h-10 rounded-full flex items-center justify-center"
       style={{
         backgroundColor: active ? color : 'transparent',
         boxShadow: active
@@ -78,7 +80,7 @@ function Planet({ src, active, color }: Planet) {
           : 'none',
       }}
     >
-      <Image src={src} alt="planet" width={50} height={50} />
+      <Image src={src} alt="planet" width={42} height={42} />
     </div>
   );
 }

--- a/src/provider/AppLayoutProvider.tsx
+++ b/src/provider/AppLayoutProvider.tsx
@@ -57,7 +57,7 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
     <div className="min-h-screen w-full flex justify-center">
       <div
         className={`
-          relative w-full min-w-[375px] max-w-[620px] overflow-hidden
+          relative w-full h-full min-w-[375px] max-w-[620px] overflow-hidden
           ${backgroundImageUrl ? 'nav-container-bg' : ''}
         `}
         style={containerStyle}
@@ -71,7 +71,6 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
             paddingBottom: isNavigationHidden ? '0px' : `${BOTTOM_NAV_HEIGHT}px`,
             WebkitOverflowScrolling: 'touch',
             overscrollBehavior: 'contain',
-            display: 'flex',
           }}
         >
           {children}

--- a/src/provider/AuthProvider.tsx
+++ b/src/provider/AuthProvider.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 
 import { ROUTE_CONFIG, routeUtils } from '@/constants/routes';
 import { useUserRole } from '@/features/signup/hooks/useUserRole';
+import { Loading } from '@/shared';
 
 interface AuthProviderProps {
   children: React.ReactNode;
@@ -49,11 +50,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // 로딩 중일 때 스피너 표시
   if (shouldFetchUserInfo && isLoading) {
-    return (
-      <div className="flex items-center justify-center w-full flex-1">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
-      </div>
-    );
+    return <Loading />;
   }
 
   // 에러나 권한 없으면 처리


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #357

### 🔎 작업 내용

- [x] 앱 레이아웃 프로바이더 버그 수정

### 📸 스크린샷 (선택)

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 홈 페이지 레이아웃이 수직 플렉스 구조로 변경되고, 배경 이미지가 제거되었습니다.
  * OrbitWithSatellite 컴포넌트의 중앙 행성 및 외계인 요소의 위치가 조정되었습니다.
  * PlanetProgressBar의 간격과 텍스트 스타일이 개선되고, 행성 아이콘 크기가 소폭 축소되었습니다.
  * AppLayoutProvider의 레이아웃 높이 및 메인 콘텐츠 영역의 flex 속성이 조정되었습니다.

* **리팩터**
  * AuthProvider에서 직접 구현된 로딩 스피너를 공용 Loading 컴포넌트로 교체하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->