### PR TITLE
UF-320 팔로우 목록에서 유저 이름을 api 연동된 내용으로 수정

### DIFF
--- a/src/features/mypage/follow/components/FollowItem.tsx
+++ b/src/features/mypage/follow/components/FollowItem.tsx
@@ -10,7 +10,7 @@ import {
 } from '../types/FollowType.types';
 
 export default function FollowItem({ user, actions, type }: FollowItemProps) {
-  const { id: userId, profileImage, isFollowing } = user;
+  const { id: userId, nickname, profileImage, isFollowing } = user;
   const { onFollow, onUnfollow } = actions;
 
   const getButtonConfig = (): FollowButtonConfig => {
@@ -57,7 +57,7 @@ export default function FollowItem({ user, actions, type }: FollowItemProps) {
           <Image src={profileImage} alt="프로필" width={50} height={50} className="rounded-full" />
         </div>
         <div>
-          <p className="body-16-bold text-white">지구인 {userId}</p>
+          <p className="body-16-bold text-white">{nickname}</p>
         </div>
       </div>
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #359 

### 🔎 작업 내용

- [x] api 정보 중 nickname으로 유저 프로필 카드 이름 수정

### 📸 스크린샷 (선택)
더미데이터여서 닉네임 옆 #가 띄어쓰기 없이 들어갑니다~!
<img width="607" height="909" alt="image" src="https://github.com/user-attachments/assets/16739b34-5ee0-44f1-9d43-5b51f7407dd2" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 팔로우 목록에서 사용자 식별자가 닉네임으로 표시되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->