### PR TITLE
UF-309 update charge page for myzet

### DIFF
--- a/src/api/types/myInfo.ts
+++ b/src/api/types/myInfo.ts
@@ -3,10 +3,10 @@ export interface MyInfoResponse {
   message: string;
   content: {
     nickname: string;
-    email: string | null;
+    email: string;
     sellMobileDataCapacityGb: number;
     sellableDataAmount: number;
     zetAsset: number;
-    profileImageUrl?: string;
+    profileImageUrl: string;
   };
 }

--- a/src/app/charge/layout.tsx
+++ b/src/app/charge/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'UFO-Fi | ZET 코인 충전소',
+  description: 'UFO-Fi의 ZET 코인을 충전할 수 있는 페이지입니다.',
+  robots: 'index, follow',
+};
+
+export default function ChargeLayout({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-full w-full">{children}</div>;
+}

--- a/src/app/charge/page.tsx
+++ b/src/app/charge/page.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import { IMAGE_PATHS } from '@/constants/images';
-import { PACKAGES } from '@/constants/packages';
+import { IMAGE_PATHS, PACKAGES } from '@/constants';
 import { ZetChargePackageCard } from '@/features/charge/components/ZetChargePackageCard';
 import { useZetCharge } from '@/features/charge/hooks/useZetCharge';
-import { TitleWithRouter } from '@/features/common/components/TitleWithRouter';
-import { Icon } from '@/shared';
-import '@/styles/globals.css';
+import { useMyInfo } from '@/features/mypage/hooks';
+import { Icon, TitleWithRouter } from '@/shared';
 
 export default function ZetChargePage() {
   const { handleChargePackage, isProcessing } = useZetCharge();
+  const { data: myInfo, isLoading: isUserLoading } = useMyInfo();
+
+  const zetAsset = myInfo?.zetAsset ?? 0;
 
   return (
     <div className="relative min-h-full flex flex-col">
@@ -17,19 +18,28 @@ export default function ZetChargePage() {
         <div className="flex items-center justify-between mb-2">
           <TitleWithRouter title="ZET 코인 충전소" iconVariant="back" />
         </div>
+
         <div className="flex items-center justify-between mb-4">
           <p className="body-16-medium text-white m-0">외계 전파 코인을 구매하세요!</p>
+
           <div className="w-[124px] h-[36px] bg-primary-700 border-2 border-blue-500 rounded-xl flex items-center justify-center">
             <Icon
               src={IMAGE_PATHS.PACKAGE_A}
               alt="패키지 아이콘"
               className="mr-2 w-[20px] h-[20px]"
             />
-            <span className="body-16-bold text-cyan-400">200</span>
-            <span className="body-16-bold text-cyan-400 ml-1">ZET</span>
+            {isUserLoading ? (
+              <span className="body-16-bold text-cyan-400">...</span>
+            ) : (
+              <>
+                <span className="body-16-bold text-cyan-400">{zetAsset}</span>
+                <span className="body-16-bold text-cyan-400 ml-1">ZET</span>
+              </>
+            )}
           </div>
         </div>
 
+        {/* 패키지 카드 */}
         <div className="flex flex-col gap-3 mb-6">
           {PACKAGES.map((pkg) => (
             <ZetChargePackageCard
@@ -43,6 +53,7 @@ export default function ZetChargePage() {
           ))}
         </div>
 
+        {/* 결제 로딩 */}
         {isProcessing && (
           <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
             <div className="bg-white rounded-lg p-6 flex flex-col items-center gap-4">

--- a/src/app/charge/page.tsx
+++ b/src/app/charge/page.tsx
@@ -8,12 +8,16 @@ import { Icon, TitleWithRouter } from '@/shared';
 
 export default function ZetChargePage() {
   const { handleChargePackage, isProcessing } = useZetCharge();
-  const { data: myInfo, isLoading: isUserLoading } = useMyInfo();
+  const { data: myInfo, isLoading: isUserLoading, error: userError } = useMyInfo();
 
   const zetAsset = myInfo?.zetAsset ?? 0;
 
+  if (userError) {
+    return null;
+  }
+
   return (
-    <div className="relative min-h-full flex flex-col">
+    <div className="min-h-full flex flex-col">
       <div className="px-4 pt-4">
         <div className="flex items-center justify-between mb-2">
           <TitleWithRouter title="ZET 코인 충전소" iconVariant="back" />
@@ -30,11 +34,13 @@ export default function ZetChargePage() {
             />
             {isUserLoading ? (
               <span className="body-16-bold text-cyan-400">...</span>
-            ) : (
+            ) : zetAsset > 0 ? (
               <>
-                <span className="body-16-bold text-cyan-400">{zetAsset}</span>
+                <span className="body-16-bold text-cyan-400">{zetAsset.toLocaleString()}</span>
                 <span className="body-16-bold text-cyan-400 ml-1">ZET</span>
               </>
+            ) : (
+              <span className="body-14-medium text-gray-400">보유 제트 없음</span>
             )}
           </div>
         </div>
@@ -56,8 +62,8 @@ export default function ZetChargePage() {
         {/* 결제 로딩 */}
         {isProcessing && (
           <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
-            <div className="bg-white rounded-lg p-6 flex flex-col items-center gap-4">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <div className="bg-white rounded-lg p-6 flex flex-col items-center gap-4 max-w-sm mx-4">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
               <p className="text-gray-700 font-medium">결제를 준비하고 있습니다...</p>
               <p className="text-gray-500 text-sm text-center">
                 잠시 후 결제창이 나타납니다.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -24,7 +24,7 @@ const LoginPage = () => {
   };
 
   return (
-    <div className="flex flex-col justify-center items-center w-full h-screen pb-[20px]">
+    <div className="flex flex-col justify-center items-center w-full min-h-screen pb-[20px]">
       <div className="flex flex-[0.9] flex-col justify-center items-center text-center gap-5 w-full h-full pb-16">
         <div className="flex flex-col justify-center items-center w-[300px] h-[80px] gap-8">
           <Image src={ICON_PATHS['UFO_LOGO']} width={134.5} height={136} alt="ufo" />
@@ -33,12 +33,12 @@ const LoginPage = () => {
             데이터는 부족해도, 은하는 연결되어 있다.
           </h3>
         </div>
+        <Button
+          className="fixed bottom-20 hover:cursor-pointer bg-[url('/images/kakao_login_button.png')] bg-no-repeat bg-center bg-cover h-10 sm:h-14 max-w-[300px] sm:max-w-[360px]"
+          size="full-width"
+          onClick={handleKakaoLogin}
+        />
       </div>
-      <Button
-        className="hover:cursor-pointer bg-[url('/images/kakao_login_button.png')] bg-no-repeat bg-center bg-cover h-10 sm:h-14 max-w-[300px] sm:max-w-[360px]"
-        size="full-width"
-        onClick={handleKakaoLogin}
-      />
     </div>
   );
 };

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -106,7 +106,7 @@ export default function MyPage() {
   // 데이터가 없는 경우
   if (!mypageInfo) {
     return (
-      <div className="w-full min-h-hull flex flex-1 items-center justify-center">
+      <div className="w-full min-h-full flex flex-1 items-center justify-center">
         <div className="text-center text-white">
           <p>프로필 정보가 없습니다</p>
           <button

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,103 +1,144 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { toast } from 'sonner';
 
-import { logoutAPI } from '@/api';
+import { logoutAPI, ApiError } from '@/api';
 import { LogoutModal } from '@/features/mypage/components';
 import MenuSection from '@/features/mypage/components/MenuSection';
 import SignalCard from '@/features/mypage/components/SignalCard';
 import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
-import { Icon } from '@/shared';
+import { Button, Icon, IconType, Loading } from '@/shared';
 import { useToastStore } from '@/stores/useToastStore';
 import { useTradeTabStore } from '@/stores/useTradeTabStore';
 
 export default function MyPage() {
   const router = useRouter();
   const { setTab } = useTradeTabStore();
-  const [isOpen, setIsOpen] = useState(false);
-  const { data: mypageInfo, error, isLoading } = useMyInfo();
+  const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
+  const { data: mypageInfo, error, isLoading, isError, refetch } = useMyInfo();
   const { setToast } = useToastStore();
 
-  const navigateToSalesHistory = () => {
+  const navigateToSalesHistory = useCallback(() => {
     setTab('sell');
     router.push('/mypage/trade');
-  };
-  const navigateToPurchaseHistory = () => {
+  }, [setTab, router]);
+
+  const navigateToPurchaseHistory = useCallback(() => {
     setTab('purchase');
     router.push('/mypage/trade');
-  };
+  }, [setTab, router]);
+
+  const navigateToTerms = useCallback(() => router.push('/mypage/service'), [router]);
+  const navigateToPrivacy = useCallback(() => router.push('/mypage/privacy'), [router]);
+  const navigateToFollow = useCallback(() => router.push('/mypage/follow'), [router]);
+  const navigateToNotification = useCallback(() => router.push('/mypage/notification'), [router]);
+  const navigateToAchievement = useCallback(() => router.push('/mypage/achievement'), [router]);
+
   const handleLogout = async () => {
     try {
       await logoutAPI.setLogout();
       setToast('로그아웃 되었습니다!', 'success');
       router.push('/login');
-    } catch {
-      toast.error('로그아웃에 실패했습니다.');
+    } catch (error) {
+      console.error('로그아웃 실패:', error);
+      if (error instanceof ApiError) {
+        toast.error(`로그아웃에 실패했습니다: ${error.message}`);
+      } else {
+        toast.error('로그아웃에 실패했습니다.');
+      }
+    } finally {
+      setIsLogoutModalOpen(false);
     }
   };
-  const navigateToTerms = () => router.push('/mypage/service');
-  const navigateToPrivacy = () => router.push('/mypage/privacy');
-  const navigateToFollow = () => router.push('/mypage/follow');
-  const navigateToNotification = () => router.push('/mypage/notification');
-  const navigateToAchievement = () => router.push('/mypage/achievement');
 
+  const handleRetry = useCallback(() => {
+    refetch();
+  }, [refetch]);
+
+  // 메뉴 아이템들
   const transactionItems = [
     { label: '판매 내역', onClick: navigateToSalesHistory },
     { label: '구매 내역', onClick: navigateToPurchaseHistory },
   ];
 
   const supportItems = [
-    { label: '로그아웃', onClick: () => setIsOpen(true) },
+    { label: '로그아웃', onClick: () => setIsLogoutModalOpen(true) },
     { label: '이용 약관', onClick: navigateToTerms },
     { label: '개인정보처리방침', onClick: navigateToPrivacy },
   ];
 
+  // 로딩 상태
   if (isLoading) {
-    return <div className="text-center text-white py-10">로딩 중...</div>;
+    return <Loading />;
+  }
+
+  // 에러 상태 처리
+  if (isError && error) {
+    const isAuthError = error instanceof ApiError && [401, 403].includes(error.statusCode);
+
+    if (isAuthError) {
+      return null;
+    }
+
+    return (
+      <div className="w-full min-h-full flex flex-1 items-center justify-center">
+        <div className="text-center">
+          <div className="text-red-400 mb-4">
+            <Icon name="AlertCircle" size={48} className="mx-auto mb-2" />
+            <p className="text-lg font-medium">프로필 정보를 불러올 수 없습니다</p>
+            <p className="text-sm text-white mt-2">
+              {error instanceof ApiError ? error.message : '네트워크 연결을 확인해주세요'}
+            </p>
+            {error instanceof ApiError && (
+              <p className="text-xs text-gray-500 mt-1">오류 코드: {error.statusCode}</p>
+            )}
+          </div>
+          <Button onClick={handleRetry} className="px-4 py-2 bg-blue-600 text-white" type="button">
+            다시 시도
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // 데이터가 없는 경우
+  if (!mypageInfo) {
+    return (
+      <div className="w-full min-h-hull flex flex-1 items-center justify-center">
+        <div className="text-center text-white">
+          <p>프로필 정보가 없습니다</p>
+          <button
+            onClick={handleRetry}
+            className="mt-4 px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
+            type="button"
+          >
+            새로고침
+          </button>
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div className="w-full text-white py-6 ">
+    <div className="w-full text-white py-6">
       {/* Signal Card */}
       <SignalCard
-        userId={mypageInfo?.nickname ?? ''}
-        profileImageUrl={mypageInfo?.profileImageUrl}
-        zetAmount={mypageInfo?.zetAsset ?? 0}
-        availableData={mypageInfo?.sellableDataAmount ?? 0}
-        maxData={mypageInfo?.sellMobileDataCapacityGb ?? 0}
+        userId={mypageInfo.nickname || '사용자'}
+        profileImageUrl={mypageInfo.profileImageUrl}
+        zetAmount={mypageInfo.zetAsset || 0}
+        availableData={mypageInfo.sellableDataAmount || 0}
+        maxData={mypageInfo.sellMobileDataCapacityGb || 0}
       />
 
-      {error && <div className="text-red-500 text-sm text-center my-4">{error.message}</div>}
       <hr className="my-6 border-white/20" />
 
-      {/* 메뉴 */}
+      {/* 메뉴 아이콘들 */}
       <div className="grid grid-cols-3 gap-4 text-center text-sm mb-4">
-        <div className="group hover:cursor-pointer" onClick={navigateToFollow}>
-          <Icon
-            name="Heart"
-            size={24}
-            className="mx-auto transition-all duration-300 group-hover:scale-110 text-white"
-          />
-          <p className="mt-2 caption-12-regular">팔로우 목록</p>
-        </div>
-        <div className="group hover:cursor-pointer" onClick={navigateToAchievement}>
-          <Icon
-            name="Star"
-            size={24}
-            className="mx-auto transition-all duration-300 group-hover:scale-110 text-white"
-          />
-          <p className="mt-2 caption-12-regular">업적 목록</p>
-        </div>
-        <div className="group hover:cursor-pointer" onClick={navigateToNotification}>
-          <Icon
-            name="Bell"
-            size={24}
-            className="mx-auto transition-all duration-300 group-hover:scale-110 text-white"
-          />
-          <p className="mt-2 caption-12-regular">알림 설정</p>
-        </div>
+        <MenuIconButton icon="Heart" label="팔로우 목록" onClick={navigateToFollow} />
+        <MenuIconButton icon="Star" label="업적 목록" onClick={navigateToAchievement} />
+        <MenuIconButton icon="Bell" label="알림 설정" onClick={navigateToNotification} />
       </div>
 
       <hr className="my-6 border-white/20" />
@@ -109,7 +150,36 @@ export default function MyPage() {
         <MenuSection title="고객 지원" items={supportItems} />
       </div>
 
-      <LogoutModal onPrimaryClick={handleLogout} isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      {/* 로그아웃 모달 */}
+      <LogoutModal
+        onPrimaryClick={handleLogout}
+        isOpen={isLogoutModalOpen}
+        onClose={() => setIsLogoutModalOpen(false)}
+      />
     </div>
+  );
+}
+
+// 메뉴 아이콘 버튼 컴포넌트
+interface MenuIconButtonProps {
+  icon: string;
+  label: string;
+  onClick: () => void;
+}
+
+function MenuIconButton({ icon, label, onClick }: MenuIconButtonProps) {
+  return (
+    <button
+      className="group p-2 rounded-lg transition-all duration-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/20 cursor-pointer"
+      onClick={onClick}
+      type="button"
+    >
+      <Icon
+        name={icon as IconType}
+        size={24}
+        className="mx-auto transition-all duration-300 group-hover:scale-110 text-white"
+      />
+      <p className="mt-2 caption-12-regular">{label}</p>
+    </button>
   );
 }

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -25,6 +25,7 @@ export const IMAGE_PATHS = {
   PACKAGE_B: '/images/zet-2.png',
   PACKAGE_C: '/images/zet-3.png',
   PACKAGE_D: '/images/zet-4.png',
+  PACKAGE_E: '/images/zet-5.png',
   PLANET_1: '/images/main/planet1.svg',
   PLANET_2: '/images/main/planet2.svg',
   PLANET_3: '/images/main/planet3.svg',

--- a/src/features/mypage/components/SignalCard.tsx
+++ b/src/features/mypage/components/SignalCard.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { IMAGE_PATHS } from '@/constants/images';
 import { Avatar } from '@/shared/ui';
 import { Button } from '@/shared/ui';
 import { Progress } from '@/shared/ui/Progress';
+
 interface SignalCardProps {
   userId: string;
-  profileImageUrl?: string;
+  profileImageUrl: string | undefined;
   zetAmount: number;
-  availableData: number; // GB
-  maxData: number; // GB
+  availableData: number;
+  maxData: number;
 }
 
 export default function SignalCard({
@@ -52,7 +54,7 @@ export default function SignalCard({
         {/* 왼쪽 캐릭터 */}
         <div className="flex flex-col items-center shrink-0">
           <Avatar size="md" className="border sm:w-[80px] sm:h-[80px]" variant="default">
-            <img
+            <Image
               src={profileImageUrl || IMAGE_PATHS.AVATAR}
               alt="지구인"
               width={64}
@@ -86,11 +88,13 @@ export default function SignalCard({
 
           <div className="caption-12-bold flex flex-col text-gray-800">
             <span>보유중인 ZET</span>
-            <div className="flex items-center">
+            <div className="flex justify-between items-center gap-2">
               <span className="body-16-bold font-bold text-chart-4">{zetAmount} ZET</span>
-              <button className="ml-auto body-14-medium rounded-md px-4 py-2 flex items-center justify-center exploration-button">
-                충전
-              </button>
+              <Link href="/charge">
+                <button className="ml-auto whitespace-nowrap body-14-medium rounded-md px-4 py-2 flex items-center justify-center exploration-button">
+                  충전
+                </button>
+              </Link>
             </div>
           </div>
         </div>
@@ -103,7 +107,7 @@ export default function SignalCard({
             className="text-gray-800 caption-8-medium h-7 px-1 py-1 whitespace-nowrap"
             onClick={() => router.push('/mypage/edit-profile')}
           >
-            ✏️ 프로필 수정
+            ✏️&nbsp;프로필 수정
           </Button>
           <Image
             src={IMAGE_PATHS.QR}

--- a/src/features/mypage/hooks/useMyInfo.ts
+++ b/src/features/mypage/hooks/useMyInfo.ts
@@ -1,20 +1,35 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { myInfoAPI } from '@/api';
+import { ApiError } from '@/api/client/axios';
 import { MyInfoResponse } from '@/api/types/myInfo';
 
 export function useMyInfo() {
-  return useQuery<MyInfoResponse['content'], Error>({
+  return useQuery<MyInfoResponse['content'], ApiError>({
     queryKey: ['myInfo'],
     queryFn: async () => {
       const data = await myInfoAPI.get();
-      if (!data) throw new Error('프로필 정보를 불러오지 못했습니다.');
+      if (!data) {
+        throw new ApiError('프로필 정보를 불러오지 못했습니다.', 404);
+      }
       return data;
     },
-    staleTime: 0, // 매번 api 호출
-    retry: 1,
-    refetchInterval: 10 * 1000, // 10초마다 polling
-    refetchOnWindowFocus: true, // 탭 전환 시 자동 refetch
-    refetchOnReconnect: true, // 네트워크 복구 시 자동 refetch
+    staleTime: 1 * 60 * 1000,
+    retry: (failureCount, error) => {
+      // ApiError의 statusCode 확인
+      if (error instanceof ApiError) {
+        const { statusCode } = error;
+        // 인증/권한/찾지못함 에러는 재시도하지 않음
+        if ([401, 403, 404, 422].includes(statusCode)) {
+          return false;
+        }
+      }
+      // 최대 2번까지 재시도
+      return failureCount < 2;
+    },
+    refetchInterval: 30 * 1000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    retryOnMount: true,
   });
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #345 

### 🔎 작업 내용

- [x] 마이페이지 보유 제트 충전 라우트 연결
- [x] 4XX 에러 시 본인 정보 페칭 재시도 하지 않도록 커스텀 훅 수정
- [x] 로그인 페이지 스크롤 제거

### 📸 스크린샷 (선택)

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 충전 페이지에 새로운 레이아웃이 추가되어, ZET 코인 잔액 표시 및 패키지 선택 UI가 개선되었습니다.
  * 마이페이지에서 팔로우, 알림, 업적 등 다양한 메뉴로 이동할 수 있는 버튼이 추가되었습니다.

* **버그 수정**
  * 마이페이지에서 프로필 정보 로딩 및 오류 처리 방식이 개선되어, 인증 오류 시 화면이 숨겨지고 기타 오류 시 재시도 버튼이 제공됩니다.
  * 로그아웃 시 오류 메시지 및 토스트 알림이 보다 명확하게 표시됩니다.

* **리팩토링**
  * 마이페이지 내 콜백 함수들이 최적화되어 불필요한 렌더링이 줄었습니다.
  * 메뉴 아이콘 버튼이 재사용 가능한 컴포넌트로 분리되었습니다.

* **스타일**
  * 로그인 페이지에서 카카오 로그인 버튼이 화면 하단에 고정되어 접근성이 향상되었습니다.
  * SignalCard에 이미지 최적화 및 버튼 레이아웃 개선이 적용되었습니다.

* **기타**
  * 이미지 상수에 새로운 패키지 이미지가 추가되었습니다.
  * 사용자 정보 API 타입이 업데이트되어 이메일과 프로필 이미지가 항상 제공되도록 변경되었습니다.
  * 사용자 정보 조회 훅의 에러 처리 및 재시도 조건이 세분화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->