### PR TITLE
UF-321 판매 등록/수정 페이지 제목 입력 필드 문자 수 표시 개선

### DIFF
--- a/src/app/sell/edit/[id]/page.tsx
+++ b/src/app/sell/edit/[id]/page.tsx
@@ -103,17 +103,17 @@ export default function SellEditPage() {
                 onChange={(e) => setTitleInput(e.target.value)}
                 placeholder="글 제목을 입력해주세요."
                 variant="blueFill"
-                maxLength={15}
+                maxLength={10}
                 error={getSellErrorMessages.title(titleInput, isValidTitle)}
               />
             </div>
           </div>
           <div
             className={`text-xs text-right ${
-              titleInput.length === 15 ? 'text-red-400' : 'text-white/60'
+              titleInput.length === 10 ? 'text-red-400' : 'text-white/60'
             }`}
           >
-            {titleInput.length}/15
+            {titleInput.length}/10
           </div>
         </div>
 

--- a/src/app/sell/edit/[id]/page.tsx
+++ b/src/app/sell/edit/[id]/page.tsx
@@ -96,7 +96,6 @@ export default function SellEditPage() {
                 src={ICON_PATHS[postData.carrier as keyof typeof ICON_PATHS] || ICON_PATHS['LGU']}
               />
             </div>
-
             <div className="flex-1">
               <Input
                 value={titleInput}

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -57,17 +57,17 @@ export default function SellPage() {
                 onChange={(e) => setTitleInput(e.target.value)}
                 placeholder="글 제목을 입력해주세요."
                 variant="blueFill"
-                maxLength={15}
+                maxLength={10}
                 error={getSellErrorMessages.title(titleInput, isValidTitle)}
               />
             </div>
           </div>
           <div
             className={`text-xs text-right ${
-              titleInput.length === 15 ? 'text-red-400' : 'text-white/60'
+              titleInput.length === 10 ? 'text-red-400' : 'text-white/60'
             }`}
           >
-            {titleInput.length}/15
+            {titleInput.length}/10
           </div>
         </div>
 

--- a/src/features/sell/utils/sellValidation.ts
+++ b/src/features/sell/utils/sellValidation.ts
@@ -1,7 +1,7 @@
 export const getSellErrorMessages = {
   title: (titleInput: string, isValidTitle: boolean) => {
     if (!titleInput) return undefined;
-    if (!isValidTitle) return '제목은 1~15자 이내여야 합니다.';
+    if (!isValidTitle) return '제목은 1~10자 이내여야 합니다.';
     return undefined;
   },
 
@@ -18,7 +18,7 @@ export const getSellErrorMessages = {
 };
 
 export const validateSellForm = {
-  title: (title: string) => title.length >= 1 && title.length <= 15,
+  title: (title: string) => title.length >= 1 && title.length <= 10,
   price: (pricePerGB: string | number, sellCapacity: number) => {
     const price = Number(pricePerGB);
     return price > 0 && price * sellCapacity >= 1;


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #363 

### 🔎 작업 내용

- [x] 판매 등록/수정 페이지 제목 입력 필드 문자 수 표시 개선

### 📸 스크린샷 (선택)

### 📢 전달사항


## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 제목 입력란의 최대 글자 수가 15자에서 10자로 변경되었습니다.
  * 최대 글자 수 도달 시 표시되는 경고 색상 및 글자 수 안내 문구가 10자로 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->