### PR TITLE
UF-328 전파 거래소 우측 하단에 맨 위 이동 버튼 추가

### DIFF
--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -5,8 +5,10 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 
 import { sellAPI } from '@/api';
+import { ScrollToTopButton } from '@/features/common/components/ScrollToTopButton';
 import { ExchangeHeader } from '@/features/exchange/components/ExchangeHeader';
 import { ExchangeList } from '@/features/exchange/components/ExchangeList';
+import { useScrollTracker } from '@/hooks/useScrollTracker';
 import { Title, Modal } from '@/shared';
 import { ReportedModal } from '@/shared/ui/Modal/ReportModal';
 import { handleApiAction } from '@/utils/handleApiAction';
@@ -14,6 +16,7 @@ import queryClient from '@/utils/queryClient';
 
 export default function ExchangePage() {
   const router = useRouter();
+  useScrollTracker(); // 스크롤 위치 추적 훅
 
   const [deleteModal, setDeleteModal] = useState({
     isOpen: false,
@@ -109,6 +112,11 @@ export default function ExchangePage() {
           onReport={handleReport}
           onPurchase={handlePurchase}
         />
+
+        {/* Scroll To Top 버튼 */}
+        <div className="justify-end flex">
+          <ScrollToTopButton />
+        </div>
       </div>
 
       {/* 삭제 확인 모달 */}

--- a/src/features/common/components/ScrollToTopButton.tsx
+++ b/src/features/common/components/ScrollToTopButton.tsx
@@ -1,0 +1,14 @@
+import { useScrollToTop } from '@/hooks/useScrollToTop';
+import { Icon } from '@/shared';
+
+export const ScrollToTopButton = () => {
+  const { show, scrollToTop } = useScrollToTop();
+
+  if (!show) return null;
+
+  return (
+    <div className="fixed bottom-20 z-50 w-10 h-10 flex items-center justify-center bg-primary-300 p-1 hover:bg-white/10 rounded-full cursor-pointer">
+      <Icon name="ArrowUp" className="w-5 h-5" color="white" onClick={scrollToTop} />
+    </div>
+  );
+};

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,0 +1,13 @@
+import { useScrollStore } from '@/stores/useScrollStore';
+
+export const useScrollToTop = () => {
+  const y = useScrollStore((s) => s.y);
+
+  const show = y > 200;
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return { show, scrollToTop };
+};

--- a/src/hooks/useScrollTracker.ts
+++ b/src/hooks/useScrollTracker.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+import { useScrollStore } from '@/stores/useScrollStore';
+
+export const useScrollTracker = () => {
+  const setY = useScrollStore((s) => s.setY);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setY(window.scrollY);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [setY]);
+};

--- a/src/shared/ui/Icons/Icons.types.ts
+++ b/src/shared/ui/Icons/Icons.types.ts
@@ -77,7 +77,8 @@ export type LucideIconType =
   | 'RefreshCw'
   | 'UserCheck'
   | 'Users'
-  | 'Focus';
+  | 'Focus'
+  | 'ArrowUp';
 
 // 커스텀 아이콘 타입
 export type CustomIconType =

--- a/src/stores/useScrollStore.ts
+++ b/src/stores/useScrollStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ScrollState {
+  y: number;
+  setY: (y: number) => void;
+}
+
+export const useScrollStore = create<ScrollState>((set) => ({
+  y: 0,
+  setY: (y) => set({ y }),
+}));


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #373 

### 🔎 작업 내용

- [x] 최상단 스크롤 이동 버튼 추가

### 📸 스크린샷 (선택)
<img width="601" height="905" alt="image" src="https://github.com/user-attachments/assets/36e114c1-a42c-4b4a-afa8-b23db8f28d48" />

### 📢 전달사항
추후 아이콘 버튼 컴포넌트 수정 후 변경해야함

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 스크롤 위치를 추적하여 화면 하단에 "맨 위로 이동" 버튼이 표시됩니다. 스크롤이 일정 이상 내려가면 버튼이 나타나며, 클릭 시 페이지가 부드럽게 맨 위로 이동합니다.  
* **스타일**
  * 상단 이동 버튼에 아이콘과 시각적 효과가 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->