### PR TITLE
UF-331 정적 이미지 아이콘의 불필요한 로딩 상태 제거

### DIFF
--- a/src/shared/ui/Icons/Icons.types.ts
+++ b/src/shared/ui/Icons/Icons.types.ts
@@ -12,6 +12,7 @@ export interface ImageIconProps extends Omit<IconProps, 'color'> {
   alt: string;
   priority?: boolean;
   fallbackIcon?: LucideIconType;
+  skipLoadingState?: boolean;
 }
 
 export interface IconWrapperProps extends IconProps {

--- a/src/shared/ui/Icons/Icons.types.ts
+++ b/src/shared/ui/Icons/Icons.types.ts
@@ -12,7 +12,6 @@ export interface ImageIconProps extends Omit<IconProps, 'color'> {
   alt: string;
   priority?: boolean;
   fallbackIcon?: LucideIconType;
-  skipLoadingState?: boolean;
 }
 
 export interface IconWrapperProps extends IconProps {


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #377 

### 🔎 작업 내용

- [x] 정적 파일과 외부 URL 구분 로직 추가
- [x] 로컬 이미지의 로딩 애니메이션 제거
- [x] 아이콘 표시 시 깜빡임 현상 해결

### 📸 스크린샷 (선택)

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 아이콘 이미지 컴포넌트에서 정적 로컬 이미지 파일에 대해 로딩 및 대체 UI를 건너뛰고 즉시 표시하도록 개선되었습니다.
  * `skipLoadingState` 옵션이 추가되어 로딩 상태를 건너뛸 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->