### PR TITLE
UF-330 변경된 API에 맞춰 내역 response 수정

### DIFF
--- a/src/api/types/history.ts
+++ b/src/api/types/history.ts
@@ -7,13 +7,14 @@ interface BaseHistoryResponse {
   title: string;
   totalZet: number;
   mobileDataType: MobileDataType;
-  totalGB: number;
 }
 
 export interface PurchaseHistoryResponse extends BaseHistoryResponse {
   purchaseHistoryId: number;
+  totalGB: number;
 }
 
 export interface SellHistoryResponse extends BaseHistoryResponse {
   status: string;
+  sellMobileDataAmountGB: number;
 }

--- a/src/app/mypage/trade/page.tsx
+++ b/src/app/mypage/trade/page.tsx
@@ -43,7 +43,9 @@ const convertToCardProps = (
     carrier: item.carrier ?? '',
     message: item.title ?? '',
     price: item.totalZet ?? 0,
-    dataAmount: item.totalGB ?? 0,
+    dataAmount: isSell
+      ? (item as SellHistoryResponse).sellMobileDataAmountGB
+      : (item as PurchaseHistoryResponse).totalGB,
     state: isSell && 'status' in item ? convertStatusToBadgeState(item.status) : 'sold',
     purchaseHistoryId: 'purchaseHistoryId' in item ? item.purchaseHistoryId : undefined,
     postId: item.postId,
@@ -135,32 +137,22 @@ const MyTradeHistoryPage = () => {
       ));
 
   return (
-    <div className="flex flex-col justify-start items-center w-full h-[calc(100vh-112px)]">
+    <div className="flex flex-col justify-start w-full min-h-full">
       <Tabs
         defaultValue="sell"
         value={tab}
         onValueChange={handleTabChange}
         className="w-full h-full"
       >
-        <TabsList className="bg-transparent w-full py-6 sm:py-8">
-          <TabsTrigger
-            className="flex body-16-bold items-center py-6 sm:py-8"
-            value="sell"
-            variant="darkTab"
-            size="full"
-          >
+        <TabsList className="my-4 w-auto px-10 gap-10">
+          <TabsTrigger value="sell" variant="darkTab" size="full">
             판매 내역
           </TabsTrigger>
-          <TabsTrigger
-            className="flex body-16-bold items-center py-6 sm:py-8"
-            value="purchase"
-            variant="darkTab"
-            size="full"
-          >
+          <TabsTrigger value="purchase" variant="darkTab" size="full">
             구매 내역
           </TabsTrigger>
         </TabsList>
-        <div ref={contentRef} className="px-8 overflow-y-auto h-full pt-4 mb-4 hide-scrollbar">
+        <div ref={contentRef} className="overflow-y-auto h-full hide-scrollbar">
           <TabsContent value="sell" className="text-white h-full">
             {sellTrade.length === 0 ? (
               <EmptyTradeNotice />


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #375

### 🔎 작업 내용
<TabsList className="my-4 w-auto px-10 gap-10"> => 탭 리스트를 통해 줄 간격 조절 가능
<img width="727" height="403" alt="image" src="https://github.com/user-attachments/assets/6c6280cc-ba96-4c28-851d-74c1cf4b203b" />
<img width="450" height="295" alt="image" src="https://github.com/user-attachments/assets/567affaa-4d14-4522-a6af-e80e68c6500d" />

- [x] API 수정
- [x] Tab 컴포넌트 조절

### 📸 스크린샷 (선택)

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 판매 내역에 판매한 모바일 데이터 용량이 별도로 표시됩니다.
  * 구매 내역에만 총 데이터 용량 정보가 표시됩니다.

* **스타일**
  * 거래 내역 페이지의 레이아웃과 탭 스타일이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->