### PR TITLE
UF-336 로그인 후 무한 리다이렉트 루프 문제 해결

### DIFF
--- a/src/app/login/success/page.tsx
+++ b/src/app/login/success/page.tsx
@@ -23,23 +23,25 @@ const SuccessPage = () => {
 
         const response = await getUserInfoAPI.getInfo();
 
+        // 전화번호 저장
+        setPhoneNumber(response.content.phoneNumber);
+
+        // 사용자 역할에 따른 리다이렉트
         switch (response.content.role) {
           case 'ROLE_NO_INFO':
-            router.push('/signup/privacy');
+            router.replace('/signup/privacy');
             break;
           case 'ROLE_REPORTED':
-            router.push('/blackhole');
+            router.replace('/blackhole');
             break;
           case 'ROLE_ADMIN':
-            router.push('/admin');
+            router.replace('/admin');
             break;
           case 'ROLE_USER':
           default:
-            router.push('/');
+            router.replace('/');
             break;
         }
-
-        setPhoneNumber(response.content.phoneNumber);
       } catch {
         setToast('회원 정보를 불러올 수 없습니다.', 'error');
         router.push('/login');

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -3,7 +3,7 @@ export const ROUTE_CONFIG = {
   PROTECTED_ROUTES: ['/sell', '/exchange', '/signal', '/mypage', '/onboarding'],
 
   // 공개 라우트 (인증 불필요)
-  PUBLIC_ROUTES: ['/', '/login', '/login/success', '/signup/**'],
+  PUBLIC_ROUTES: ['/', '/login', '/login/success', '/signup/**', '/blackhole'],
 
   // 회원가입 관련 라우트
   SIGNUP_ROUTES: ['/signup/privacy', '/signup/profile', '/signup/plan'],

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { routeUtils } from '@/constants/routes';
-
 export function middleware(request: NextRequest) {
   if (process.env.DISABLE_AUTH_MIDDLEWARE === 'true') {
     return NextResponse.next();
@@ -11,46 +9,11 @@ export function middleware(request: NextRequest) {
   const authToken = request.cookies.get('Authorization')?.value;
   const isAuthenticated = !!authToken;
 
-  // 예외 경로들 (미들웨어에서 처리하지 않음)
-  const exemptPaths = [
-    '/api',
-    '/_next',
-    '/favicon.ico',
-    '/images',
-    '/icons',
-    '/login',
-    '/signup',
-    '/blackhole',
-  ];
+  // 인증이 라우트들만 체크
+  const protectedRoutes = ['/sell', '/exchange', '/signal', '/mypage', '/admin'];
+  const needsAuth = protectedRoutes.some((route) => pathname.startsWith(route));
 
-  const conditionalRoutes = ['/', '/onboarding'];
-
-  // 예외 경로 체크
-  if (exemptPaths.some((path) => pathname.startsWith(path))) {
-    return NextResponse.next();
-  }
-
-  // 공개 라우트는 인증 체크 안함
-  if (routeUtils.isPublicRoute(pathname)) {
-    return NextResponse.next();
-  }
-
-  // 홈페이지와 온보딩은 로그인된 사용자만 접근 가능
-  if (conditionalRoutes.includes(pathname)) {
-    if (!isAuthenticated) {
-      return NextResponse.redirect(new URL('/login', request.url));
-    }
-
-    return NextResponse.next();
-  }
-
-  // 1. 비로그인 유저가 보호된 라우트 접근 시 → /login
-  if (!isAuthenticated && routeUtils.isProtectedRoute(pathname)) {
-    return NextResponse.redirect(new URL('/login', request.url));
-  }
-
-  // 2. 비로그인 유저가 관리자 페이지 접근 시 → /login
-  if (pathname.startsWith('/admin') && !isAuthenticated) {
+  if (needsAuth && !isAuthenticated) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 

--- a/src/provider/AuthProvider.tsx
+++ b/src/provider/AuthProvider.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useRouter, usePathname } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
-import { ROUTE_CONFIG, routeUtils } from '@/constants/routes';
 import { useUserRole } from '@/features/signup/hooks/useUserRole';
 import { Loading } from '@/shared';
 
@@ -14,76 +13,63 @@ interface AuthProviderProps {
 export function AuthProvider({ children }: AuthProviderProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const isPublicRoute = routeUtils.isPublicRoute(pathname);
-  const shouldFetchUserInfo = !isPublicRoute;
-  const { userRole, isLoading, error } = useUserRole(shouldFetchUserInfo);
+  const [hasRedirected, setHasRedirected] = useState(false);
+
+  // 모든 페이지에서 사용자 정보를 가져옴
+  const { userRole, isLoading, error } = useUserRole(true);
 
   useEffect(() => {
-    // 개발 환경에서는 체크 안함
-    if (process.env.NODE_ENV === 'development') return;
+    // 이미 리다이렉트했거나 로딩 중이면 처리하지 않음
+    if (hasRedirected || isLoading) return;
 
-    // 공개 라우트는 체크하지 않음
-    if (isPublicRoute) {
-      return;
-    }
-
-    // 로딩 중이면 대기
-    if (shouldFetchUserInfo && isLoading) {
-      return;
-    }
-
-    // 에러가 발생한 경우 로그인 페이지로 이동
-    if (shouldFetchUserInfo && error) {
+    // 에러 발생 시 로그인 페이지로 (로그인 관련 페이지가 아닌 경우만)
+    if (error && !pathname.startsWith('/login') && !pathname.startsWith('/signup')) {
+      setHasRedirected(true);
       router.replace('/login');
       return;
     }
 
-    // 사용자 정보를 가져왔지만 userRole이 없는 경우
-    if (shouldFetchUserInfo && !isLoading && !userRole) {
-      router.replace('/login');
-      return;
-    }
-
-    if (shouldFetchUserInfo && userRole) {
-      // 1. ROLE_REPORTED 유저는 모든 경로 차단 후 블랙홀로 이동
+    // 사용자 역할에 따른 처리
+    if (userRole) {
+      // 1. ROLE_REPORTED 유저는 블랙홀로
       if (userRole === 'ROLE_REPORTED' && pathname !== '/blackhole') {
+        setHasRedirected(true);
         router.replace('/blackhole?mode=self');
         return;
       }
 
-      // 2. ROLE_NO_INFO 유저는 회원가입 페이지로 이동
-      if (userRole === 'ROLE_NO_INFO' && !routeUtils.isSignupRoute(pathname)) {
+      // 2. ROLE_NO_INFO 유저는 회원가입으로
+      if (userRole === 'ROLE_NO_INFO' && !pathname.startsWith('/signup')) {
+        setHasRedirected(true);
         router.replace('/signup/privacy');
         return;
       }
 
-      // 3. 관리자 페이지는 관리자만 접근 가능
-      if (routeUtils.isAdminRoute(pathname) && userRole !== 'ROLE_ADMIN') {
-        router.replace(ROUTE_CONFIG.DEFAULT_REDIRECT);
+      // 3. ROLE_ADMIN이 아닌 사용자가 관리자 페이지 접근
+      if (pathname.startsWith('/admin') && userRole !== 'ROLE_ADMIN') {
+        setHasRedirected(true);
+        router.replace('/');
         return;
       }
 
-      // 4. 일반 사용자가 회원가입 페이지에 접근하면 홈으로 이동
-      if (userRole === 'ROLE_USER' && routeUtils.isSignupRoute(pathname)) {
-        router.replace(ROUTE_CONFIG.DEFAULT_REDIRECT);
+      // 4. 일반 사용자가 회원가입 페이지 접근
+      if (userRole === 'ROLE_USER' && pathname.startsWith('/signup')) {
+        setHasRedirected(true);
+        router.replace('/');
         return;
       }
     }
-  }, [pathname, router, userRole, isLoading, error, isPublicRoute, shouldFetchUserInfo]);
 
-  // 공개 라우트는 바로 렌더링
-  if (isPublicRoute) {
-    return <>{children}</>;
-  }
+    // 홈페이지에서 비로그인 사용자 처리
+    if (pathname === '/' && !userRole && !isLoading && !error) {
+      setHasRedirected(true);
+      router.replace('/login');
+      return;
+    }
+  }, [pathname, router, userRole, isLoading, error, hasRedirected]);
 
-  // 로딩 중일 때 스피너 표시
-  if (shouldFetchUserInfo && isLoading) {
-    return <Loading />;
-  }
-
-  // 에러나 권한 없으면 처리하지 않고 useEffect에서 리다이렉트하도록 함
-  if (shouldFetchUserInfo && (error || !userRole)) {
-    // 로딩 화면을 보여주면서 useEffect에서 리다이렉트 처리
+  // 로딩 중일 때
+  if (isLoading) {
     return <Loading />;
   }
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #385 

### 🔎 작업 내용

- [x] 홈페이지를 공개 라우트로 변경하여 미들웨어 간섭 방지
- [x] 미들웨어를 특정 보호 라우트만 체크하도록 단순화
- [x] AuthProvider에 중복 리다이렉트 방지 로직 추가


### 📸 스크린샷 (선택)

### 📢 전달사항
> 머지할게요 바로!
<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * `/blackhole` 경로가 공개 페이지로 추가되어 인증 없이 접근할 수 있습니다.

* **버그 수정**
  * 로그인 성공 시 사용자 전화번호가 즉시 저장되며, 역할 기반 리디렉션 시 `router.replace`를 사용하여 더 일관된 이동이 이루어집니다.

* **리팩터링**
  * 인증 미들웨어가 간소화되어 보호된 경로에만 인증 검사를 적용합니다.
  * 인증 및 역할 기반 리디렉션 로직이 통합되어 모든 페이지에서 사용자 정보를 일관되게 확인합니다.  
  * 로딩 중에는 항상 스피너가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->