### PR TITLE
UF-251 편지 로직 수정 및 메인화면과 API 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "firebase-admin": "^13.4.0",
         "formidable": "^3.5.4",
         "gtag": "^1.0.1",
+        "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.525.0",
         "next": "15.3.4",
         "next-themes": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "firebase-admin": "^13.4.0",
     "formidable": "^3.5.4",
     "gtag": "^1.0.1",
+    "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.525.0",
     "next": "15.3.4",
     "next-themes": "^0.4.6",

--- a/src/app/api/story/letters/route.ts
+++ b/src/app/api/story/letters/route.ts
@@ -5,25 +5,34 @@ import { OpenAI } from 'openai';
 
 import { prisma } from '@/lib/prisma';
 
+// OpenAI 인스턴스 초기화
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
+/**
+ * GET 요청 처리 - 사용자의 편지 리스트 조회
+ */
 export async function GET() {
+  // 쿠키에서 JWT 토큰 추출
   const token = (await cookies()).get('Authorization')?.value;
   if (!token) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   try {
+    // Base64 디코딩된 secret 키로 JWT 검증
     const secret = Buffer.from(process.env.JWT_SECRET!, 'base64');
     const decoded = jwt.verify(token, secret) as jwt.JwtPayload;
 
+    // 사용자 ID 추출 (id 또는 sub 필드 사용)
     const userId = decoded.id ?? decoded.sub;
 
+    // 해당 사용자의 모든 편지(step 순으로 정렬) 조회
     const letters = await prisma.voyage_letters.findMany({
       where: { user_id: userId },
       orderBy: { step: 'asc' },
     });
 
+    // 날짜 포맷 및 ID 문자열 변환
     const serialized = letters.map((l) => ({
       id: l.id.toString(),
       user_id: l.user_id.toString(),
@@ -40,24 +49,32 @@ export async function GET() {
   }
 }
 
+/**
+ * POST 요청 처리 - 항해 편지 생성
+ */
 export async function POST() {
+  // 쿠키에서 JWT 토큰 추출
   const token = (await cookies()).get('Authorization')?.value;
   if (!token) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   try {
+    // JWT 검증
     const secret = Buffer.from(process.env.JWT_SECRET!, 'base64');
     const decoded = jwt.verify(token, secret) as jwt.JwtPayload;
-
     const userId = decoded.id ?? decoded.sub;
 
-    const maxDepth = 5;
-    const visited = new Set<bigint>();
-    const path: bigint[] = [];
+    const maxDepth = 5; // 최대 깊이 제한
+    const visited = new Set<bigint>(); // 방문한 노드 ID 저장
+    const path: bigint[] = []; // BFS 탐색 경로 저장
 
+    /**
+     * 구매 이력을 따라 seller의 seller까지 BFS 탐색
+     */
     async function bfs(currentId: bigint, depth = 0) {
       if (depth >= maxDepth || visited.has(currentId)) return;
+
       visited.add(currentId);
       path.push(currentId);
 
@@ -74,8 +91,10 @@ export async function POST() {
       }
     }
 
+    // BFS 시작
     await bfs(userId);
 
+    // 경로에 포함된 사용자 정보 조회
     const users = await prisma.users.findMany({
       where: { id: { in: path } },
       select: { id: true, name: true },
@@ -83,10 +102,12 @@ export async function POST() {
 
     const responses = [];
 
+    // 경로를 따라 편지 생성 또는 조회
     for (let i = 1; i < Math.min(path.length, 6); i++) {
       const fromId = path[i - 1];
       const toId = path[i];
 
+      // 이미 생성된 편지가 있으면 재생성하지 않음
       const existing = await prisma.voyage_letters.findUnique({
         where: {
           user_id_step: {
@@ -101,11 +122,14 @@ export async function POST() {
         continue;
       }
 
+      // 편지에 들어갈 이름 가져오기 (없을 경우 기본값 사용)
       const fromName = users.find((u) => u.id === fromId)?.name ?? '어느 항해자';
       const toName = users.find((u) => u.id === toId)?.name ?? '다른 별';
 
+      // AI 프롬프트 구성
       const prompt = `당신은 은하계 항해 AI입니다. ${fromName}의 데이터가 ${toName}에게 도달했습니다.\n이 사실을 짧고 감성적인 편지를 한 줄로 요약해주세요.`;
 
+      // GPT 모델을 이용한 편지 생성
       const completion = await openai.chat.completions.create({
         model: 'gpt-4.1-mini',
         messages: [{ role: 'user', content: prompt }],
@@ -113,6 +137,7 @@ export async function POST() {
 
       const content = completion.choices[0].message.content ?? '[편지 없음]';
 
+      // DB에 편지 저장
       const saved = await prisma.voyage_letters.create({
         data: {
           user_id: userId,

--- a/src/app/test/letters/page.tsx
+++ b/src/app/test/letters/page.tsx
@@ -17,22 +17,21 @@ export default function VoyageLetters() {
       setLoading(true);
       setError(null);
       try {
-        const postRes = await fetch('/api/story/letters', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
+        const postRes = await fetch('/api/story/letters');
 
         if (!postRes.ok) {
           throw new Error('편지 전송 실패');
         }
 
         const getRes = await fetch('/api/story/letters');
+        if (!getRes.ok) {
+          throw new Error('편지 불러오기 실패');
+        }
+
         const data = await getRes.json();
         setLetters(data);
       } catch (e) {
-        console.error('편지 불러오기 실패:', e);
+        console.error('편지 로직 실패:', e);
         setError('편지를 불러오는데 실패했습니다. 다시 시도해주세요.');
       } finally {
         setLoading(false);

--- a/src/app/test/letters/page.tsx
+++ b/src/app/test/letters/page.tsx
@@ -17,10 +17,19 @@ export default function VoyageLetters() {
       setLoading(true);
       setError(null);
       try {
-        // TODO: userId 수정 필요
-        await fetch(`/api/story/letters/${10}`, { method: 'POST' });
-        const res = await fetch(`/api/story/letters/${10}`);
-        const data = await res.json();
+        const postRes = await fetch('/api/story/letters', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (!postRes.ok) {
+          throw new Error('편지 전송 실패');
+        }
+
+        const getRes = await fetch('/api/story/letters');
+        const data = await getRes.json();
         setLetters(data);
       } catch (e) {
         console.error('편지 불러오기 실패:', e);


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #388 

### 🔎 작업 내용

- [x] 편지 로직 수정
- [x] 메인화면과 API 연결

### 📸 스크린샷 (선택)
<img width="770" height="905" alt="image" src="https://github.com/user-attachments/assets/5c0ddc75-3f42-4d42-a87f-07545f7aeb26" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * JWT 기반 인증이 적용되어, 쿠키에서 토큰을 추출해 사용자를 인증하도록 변경되었습니다.

* **버그 수정**
  * 인증 실패 시 401 Unauthorized 오류가 반환되도록 오류 처리가 개선되었습니다.

* **리팩터링**
  * API 요청 시 URL에서 userId를 제거하고, 인증된 사용자 정보만을 사용하도록 로직이 리팩터링되었습니다.
  * 편지 생성 및 조회 로직이 간소화되었습니다.

* **기타**
  * `jsonwebtoken` 패키지가 새로 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->