### PR TITLE
UF-341 회원가입 페이지 높이 조절

### DIFF
--- a/src/app/signup/plan/page.tsx
+++ b/src/app/signup/plan/page.tsx
@@ -79,7 +79,7 @@ const PlanPage = () => {
   };
 
   return (
-    <div className="w-full min-h-full flex flex-col">
+    <div className="w-full min-h-[calc(100dvh-120px)] flex flex-col">
       <div className="flex-1 flex flex-col justify-start items-start">
         <Title title="회원가입" className="body-20-bold w-full pl-0 mb-6" />
         <div className="flex flex-col items-start gap-6 w-full">

--- a/src/app/signup/plan/page.tsx
+++ b/src/app/signup/plan/page.tsx
@@ -79,7 +79,7 @@ const PlanPage = () => {
   };
 
   return (
-    <div className="w-full min-h-[calc(100dvh-120px)] flex flex-col">
+    <div className="w-full min-h-[calc(100dvh - 120px)] flex flex-col">
       <div className="flex-1 flex flex-col justify-start items-start">
         <Title title="회원가입" className="body-20-bold w-full pl-0 mb-6" />
         <div className="flex flex-col items-start gap-6 w-full">

--- a/src/app/signup/profile/page.tsx
+++ b/src/app/signup/profile/page.tsx
@@ -33,8 +33,8 @@ const ProfilePage = () => {
   };
 
   return (
-    <div className="w-full min-h-full flex flex-col">
-      <form onSubmit={handleSubmit(onSubmit)} className="flex-1 flex flex-col">
+    <div className="w-full min-h-[calc(100dvh-120px)] flex flex-col justify-between">
+      <form onSubmit={handleSubmit(onSubmit)} className="flex-1 flex flex-col gap-6">
         <div className="flex-1 flex flex-col justify-start items-start">
           <Title title="회원가입" className="body-20-bold w-full pl-0 mb-6" />
 
@@ -74,7 +74,6 @@ const ProfilePage = () => {
             </div>
           </div>
         </div>
-
         {/* 고정된 하단 버튼 */}
         <div className="sticky bottom-0 bg-inherit pb-4">
           <Button type="submit" size="full-width" className="body-16-medium h-14 text-white">

--- a/src/app/signup/profile/page.tsx
+++ b/src/app/signup/profile/page.tsx
@@ -33,7 +33,7 @@ const ProfilePage = () => {
   };
 
   return (
-    <div className="w-full min-h-[calc(100dvh-120px)] flex flex-col justify-between">
+    <div className="w-full min-h-[calc(100dvh - 120px)] flex flex-col justify-between">
       <form onSubmit={handleSubmit(onSubmit)} className="flex-1 flex flex-col gap-6">
         <div className="flex-1 flex flex-col justify-start items-start">
           <Title title="회원가입" className="body-20-bold w-full pl-0 mb-6" />


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #397

### 🔎 작업 내용

- [x] profile 페이지 높이 조절
- [x] plan 페이지 높이 조절

### 📸 스크린샷 (선택)
<img width="758" height="900" alt="image" src="https://github.com/user-attachments/assets/cc825f0c-db2e-4ef3-953f-41b51698b41b" />

<img width="758" height="900" alt="image" src="https://github.com/user-attachments/assets/2c6315c9-712a-4f8d-8914-915e55560832" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 플랜 및 프로필 페이지의 레이아웃이 개선되어, 화면 높이에 맞게 컨테이너가 조정되고 요소 간 간격이 향상되었습니다.  
  * 프로필 페이지에서 폼 내부 요소들의 세로 간격이 넓어져 가독성이 좋아졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->