### PR TITLE
UF-343 QA 1차 수정 0731-v1

### DIFF
--- a/src/app/exchange/notification/page.tsx
+++ b/src/app/exchange/notification/page.tsx
@@ -18,7 +18,6 @@ const FilterNotificationPage = () => {
   useFilteredItemCount();
   const router = useRouter();
   const [selectedCarriers, setSelectedCarriers] = useState<Carrier[]>([Carrier.SKT]);
-  const [selectedReputations, setSelectedReputations] = useState<string[]>(['첫 출발']);
   const [isLoading, setIsLoading] = useState(false);
 
   // 통신사 선택 토글
@@ -28,16 +27,6 @@ const FilterNotificationPage = () => {
         ? prev.filter((c) => c !== carrier)
         : [...prev, carrier];
       return newCarriers;
-    });
-  };
-
-  // 평판 선택 토글
-  const toggleReputation = (reputation: string) => {
-    setSelectedReputations((prev) => {
-      const newReputations = prev.includes(reputation)
-        ? prev.filter((r) => r !== reputation)
-        : [...prev, reputation];
-      return newReputations;
     });
   };
 
@@ -95,7 +84,6 @@ const FilterNotificationPage = () => {
   // 전체 초기화
   const handleReset = () => {
     setSelectedCarriers([Carrier.SKT]);
-    setSelectedReputations(['첫 출발']);
     setData([minData]);
     setRange([minValue, maxValue]);
     toast.info('전체 조건이 초기화되었습니다.');
@@ -104,12 +92,12 @@ const FilterNotificationPage = () => {
   return (
     <div className="flex flex-col justify-start items-center w-full min-h-full">
       <Title title="알림 조건 설정" iconVariant="back" />
-      <div className="overflow-y-auto flex flex-col gap-4 h-full mb-4 hide-scrollbar">
+      <div className="overflow-y-auto flex flex-col gap-4 h-full mb-4 hide-scrollbar w-full px-4">
         {/* 통신사 선택 */}
-        <FilterBox name="통신사" isMultipleSelection={true}>
+        <FilterBox name="통신사" isMultipleSelection={true} className="w-full">
           <div className="flex flex-wrap w-full items-center gap-2">
             <Icon name="RotateCw" />
-            <div className="flex justify-start items-center gap-2">
+            <div className="flex justify-start items-center gap-2 flex-wrap">
               {Object.values(Carrier).map((carrier) => {
                 const displayName = CARRIER_DISPLAY_NAMES[carrier];
                 const isSelected = selectedCarriers.includes(carrier);
@@ -130,7 +118,7 @@ const FilterNotificationPage = () => {
         </FilterBox>
 
         {/* 용량 선택 */}
-        <FilterBox className="pb-10" name="용량">
+        <FilterBox className="pb-10 w-full" name="용량">
           <div className="w-full h-fit mt-2">
             <DataSlider
               value={data}
@@ -146,7 +134,7 @@ const FilterNotificationPage = () => {
         </FilterBox>
 
         {/* 단위가격 선택 */}
-        <FilterBox name="단위가격">
+        <FilterBox name="단위가격" className="w-full">
           <DataRangeSlider
             value={range}
             onValueChange={setRange}
@@ -155,31 +143,6 @@ const FilterNotificationPage = () => {
             minLabel={`${minValue}ZET`}
             maxLabel={`${maxValue}ZET`}
           />
-        </FilterBox>
-
-        {/* 평판 선택 */}
-        <FilterBox name="평판" isMultipleSelection={true}>
-          <div className="flex w-full items-center gap-3">
-            <Icon name="RotateCw" />
-            <div className="flex flex-wrap justify-center items-center gap-2">
-              {['첫 출발', '우주 새싹', '별빛 상인', '은하 베테랑', '우주 전설'].map(
-                (reputation) => {
-                  const isSelected = selectedReputations.includes(reputation);
-
-                  return (
-                    <Chip
-                      key={reputation}
-                      selected={isSelected}
-                      className="cursor-pointer transition-colors"
-                      onClick={() => toggleReputation(reputation)}
-                    >
-                      {reputation}
-                    </Chip>
-                  );
-                },
-              )}
-            </div>
-          </div>
         </FilterBox>
 
         {/* 버튼 영역 */}
@@ -204,22 +167,6 @@ const FilterNotificationPage = () => {
           >
             {isLoading ? '저장 중...' : '알림 조건 저장'}
           </Button>
-        </div>
-
-        {/* TODO: 현재 선택된 조건을 표시하며, 배포 이후 이 부분은 지울 예정 */}
-        <div className="bg-gray-50 p-3 rounded-lg text-sm text-black">
-          <div className="font-semibold mb-2">현재 설정:</div>
-          <div>
-            통신사:{' '}
-            {selectedCarriers.length > 0
-              ? selectedCarriers.map((c) => CARRIER_DISPLAY_NAMES[c]).join(', ')
-              : '선택 없음'}
-          </div>
-          <div>용량: {data[0]}GB</div>
-          <div>
-            가격: {range[0]} - {range[1]} ZET
-          </div>
-          <div className="mt-2 text-xs text-gray-500">※ 평판 필터는 현재 지원하지 않습니다</div>
         </div>
       </div>
     </div>

--- a/src/app/exchange/purchase/[id]/step2/page.tsx
+++ b/src/app/exchange/purchase/[id]/step2/page.tsx
@@ -135,7 +135,7 @@ export default function Step2Page() {
       {/* 안내 문구 */}
       <div className="text-center text-gray-300 text-sm mb-4">
         <p>
-          번호가 다르면 마이페이지에서
+          개인정보가 다르면 마이페이지에서
           <br />
           수정 후 다시 시도해주세요.
         </p>

--- a/src/features/exchange/components/FilterBox.tsx
+++ b/src/features/exchange/components/FilterBox.tsx
@@ -1,9 +1,10 @@
 'use client';
+
 import React from 'react';
 
 import { cn } from '@/lib/utils';
-
 import '@/styles/globals.css';
+
 import { FilterBoxProps } from '../types/FilterBoxProps';
 
 interface FilterBoxWithChildren extends FilterBoxProps {
@@ -20,7 +21,7 @@ export const FilterBox = ({
   return (
     <div
       className={cn(
-        'relative min-w-full min-h-fit rounded-2xl px-4 py-3 text-white shadow-md overflow-hidden',
+        'relative w-full min-h-fit rounded-2xl p-4 py-3 text-white shadow-md overflow-hidden',
         className,
       )}
     >
@@ -32,11 +33,11 @@ export const FilterBox = ({
         }}
       />
       <div className="relative z-10 flex flex-col items-start justify-start w-full">
-        <div className="mb-2 body-18-bold">
+        <div className="mb-2 body-18-bold w-full">
           {name}
           {isMultipleSelection && <p className="caption-11-regular">중복 선택 가능</p>}
         </div>
-        {children}
+        <div className="w-full">{children}</div>
       </div>
     </div>
   );

--- a/src/features/mypage/components/SignalCard.tsx
+++ b/src/features/mypage/components/SignalCard.tsx
@@ -26,18 +26,21 @@ export default function SignalCard({
 
   return (
     <div
-      className="rounded-xl shadow-lg border-[4px] w-full max-w-[620px] mx-auto"
+      className="rounded-xl shadow-lg border-[4px] w-full max-w-[620px] mx-auto min-w-0"
       style={{
         borderColor: 'var(--chart-4)',
         backgroundColor: 'var(--color-background-card)',
       }}
     >
-      <div className="text-center py-2">
-        <h2 className="heading-24-bold" style={{ color: 'var(--color-badge-hover-dark)' }}>
+      <div className="text-center py-2 px-2">
+        <h2
+          className="heading-20-bold sm:heading-24-bold"
+          style={{ color: 'var(--color-badge-hover-dark)' }}
+        >
           UPHONIAN SIGNAL CARD
         </h2>
         <p
-          className="caption-10-regular"
+          className="caption-8-regular sm:caption-10-regular"
           style={{
             color: 'var(--color-badge-hover-dark)',
             opacity: 0.6,
@@ -48,21 +51,25 @@ export default function SignalCard({
         <hr className="my-1 border-black/30" />
       </div>
 
-      <div className="flex justify-between items-start px-4 sm:px-6 pb-3 gap-3 sm:gap-5">
+      <div className="flex justify-between items-start px-2 sm:px-4 md:px-6 pb-3 gap-2 sm:gap-3 md:gap-5">
         {/* 왼쪽 캐릭터 */}
         <div className="flex flex-col items-center shrink-0">
-          <Avatar size="md" className="border sm:w-[80px] sm:h-[80px]" variant="default">
+          <Avatar
+            size="sm"
+            className="border sm:w-[64px] sm:h-[64px] md:w-[80px] md:h-[80px]"
+            variant="default"
+          >
             <Image
               src={profileImageUrl || IMAGE_PATHS.AVATAR}
               alt="지구인"
-              width={64}
-              height={64}
-              className="rounded-md w-full h-full object-cover"
+              width={48}
+              height={48}
+              className="rounded-md w-full h-full object-cover sm:w-[64px] sm:h-[64px] md:w-[80px] md:h-[80px]"
               style={{ borderColor: 'var(--chart-4)' }}
             />
           </Avatar>
           <button
-            className="w-[5rem] mt-2 rounded-md text-xs text-white py-0.5"
+            className="w-[4rem] sm:w-[5rem] mt-2 rounded-md text-[10px] sm:text-xs text-white py-0.5 px-1"
             style={{ backgroundColor: 'var(--chart-4)' }}
           >
             🌱 지구 새싹
@@ -70,26 +77,28 @@ export default function SignalCard({
         </div>
 
         {/* 가운데 텍스트 */}
-        <div className="flex-1 space-y-1">
+        <div className="flex-1 space-y-1 min-w-0">
           <div className="flex justify-between items-center">
-            <span className="body-20-bold text-black">
+            <span className="body-16-bold sm:body-20-bold text-black truncate">
               <span className="font-bold">{userId ? userId : '지구인'}</span>
             </span>
           </div>
 
-          <div className="flex items-center caption-12-bold text-gray-800">
-            <span>이번 달 판매 가능 용량</span>
+          <div className="flex items-center caption-10-bold sm:caption-12-bold text-gray-800">
+            <span className="truncate">이번 달 판매 가능 용량</span>
           </div>
 
           <Progress usedStorage={availableData} totalStorage={maxData} size="sm" />
           <hr className="border-black/30" />
 
-          <div className="caption-12-bold flex flex-col text-gray-800">
+          <div className="caption-10-bold sm:caption-12-bold flex flex-col text-gray-800">
             <span>보유중인 ZET</span>
-            <div className="flex justify-between items-center gap-2">
-              <span className="body-16-bold font-bold text-chart-4">{zetAmount} ZET</span>
+            <div className="flex justify-between items-center gap-1 sm:gap-2">
+              <span className="body-14-bold sm:body-16-bold font-bold text-chart-4 truncate">
+                {zetAmount} ZET
+              </span>
               <Link href="/charge">
-                <button className="ml-auto whitespace-nowrap body-14-medium rounded-md px-4 py-2 flex items-center justify-center exploration-button">
+                <button className="whitespace-nowrap caption-12-medium sm:body-14-medium rounded-md px-2 sm:px-4 py-1 sm:py-2 flex items-center justify-center exploration-button text-xs sm:text-sm">
                   충전
                 </button>
               </Link>
@@ -98,11 +107,11 @@ export default function SignalCard({
         </div>
 
         {/* 오른쪽 QR & 칩 */}
-        <div className="flex flex-col items-end gap-2 shrink-0">
+        <div className="flex flex-col items-end gap-1 sm:gap-2 shrink-0">
           <Button
             variant="outline"
             size="compact"
-            className="text-gray-800 caption-8-medium h-7 px-1 py-1 whitespace-nowrap"
+            className="text-gray-800 caption-6-medium sm:caption-8-medium h-6 sm:h-7 px-1 py-1 whitespace-nowrap text-[8px] sm:text-[10px]"
             onClick={() => router.push('/mypage/edit-profile')}
           >
             ✏️&nbsp;프로필 수정
@@ -110,16 +119,16 @@ export default function SignalCard({
           <Image
             src={IMAGE_PATHS.QR}
             alt="QR 코드"
-            width={64}
-            height={64}
-            className="sm:w-[80px] sm:h-[80px]"
+            width={48}
+            height={48}
+            className="sm:w-[64px] sm:h-[64px] md:w-[80px] md:h-[80px]"
           />
           <Image
             src={IMAGE_PATHS.IC}
             alt="칩"
-            width={40}
-            height={40}
-            className="mt-2 sm:w-[50px] sm:h-[50px]"
+            width={32}
+            height={32}
+            className="mt-1 sm:mt-2 sm:w-[40px] sm:h-[40px] md:w-[50px] md:h-[50px]"
           />
         </div>
       </div>

--- a/src/features/mypage/components/SignalCard.tsx
+++ b/src/features/mypage/components/SignalCard.tsx
@@ -32,15 +32,12 @@ export default function SignalCard({
         backgroundColor: 'var(--color-background-card)',
       }}
     >
-      <div className="text-center py-2 px-2">
-        <h2
-          className="heading-20-bold sm:heading-24-bold"
-          style={{ color: 'var(--color-badge-hover-dark)' }}
-        >
+      <div className="text-center py-2">
+        <h2 className="heading-24-bold" style={{ color: 'var(--color-badge-hover-dark)' }}>
           UPHONIAN SIGNAL CARD
         </h2>
         <p
-          className="caption-8-regular sm:caption-10-regular"
+          className="caption-8-regular"
           style={{
             color: 'var(--color-badge-hover-dark)',
             opacity: 0.6,

--- a/src/provider/AppLayoutProvider.tsx
+++ b/src/provider/AppLayoutProvider.tsx
@@ -70,6 +70,9 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
             minHeight: '100dvh',
             paddingTop: isNavigationHidden ? '0px' : `${NAV_HEIGHT}px`,
             paddingBottom: isNavigationHidden ? '0px' : `${BOTTOM_NAV_HEIGHT}px`,
+            height: isNavigationHidden
+              ? '100dvh'
+              : `calc(100dvh - ${NAV_HEIGHT + BOTTOM_NAV_HEIGHT}px)`,
             WebkitOverflowScrolling: 'touch',
             overscrollBehavior: 'contain',
           }}

--- a/src/provider/AuthProvider.tsx
+++ b/src/provider/AuthProvider.tsx
@@ -40,7 +40,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         return;
       }
 
-      // 2. ROLE_NO_INFO 유저는 회원가입으로
+      // 2. ROLE_NO_INFO 유저는 회원가입으로 (단, 이미 회원가입 페이지에 있지 않은 경우만)
       if (userRole === 'ROLE_NO_INFO' && !pathname.startsWith('/signup')) {
         setHasRedirected(true);
         router.replace('/signup/privacy');
@@ -58,6 +58,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (userRole === 'ROLE_USER' && pathname.startsWith('/signup')) {
         setHasRedirected(true);
         router.replace('/');
+        return;
+      }
+
+      // 5. 홈 리다이렉트
+      // 로그인된 사용자가 로그인 페이지 접근 시 홈으로 리다이렉트
+      // 만약 어드민이라면 백오피스로 이동
+      if (userRole === 'ROLE_USER' && pathname.startsWith('/login')) {
+        setHasRedirected(true);
+        router.replace('/');
+        return;
+      } else if (userRole === 'ROLE_ADMIN' && pathname.startsWith('/login')) {
+        setHasRedirected(true);
+        router.replace('/admin');
         return;
       }
     }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #401 

### 🔎 작업 내용

- [x] AppLayoutProvider 메인 영역 높이 수정 - 상단(56px)과 하단(64px) 네비게이션을 모두 제외한 정확한 가용 높이 계산
- [x] SignalCard 반응형 디자인 개선 - 최소 너비 375px에서 컴포넌트가 깨지지 않도록 수정, 텍스트 오버플로우 방지
- [x] AuthProvider 미들웨어 개선 - 회원가입 완료 후 중복 리다이렉트 방지, 로그인된 사용자의 로그인 페이지 접근 차단
- [x] 관리자 페이지 Header에 사용자명 표시, 로그아웃 버튼 및 확인 모달 구현
- [x] 알림 조건 설정 페이지 정리 - 평판 필터링 기능 제거, FilterBox 전체 너비 사용하도록 수정
- [x] 구매 Step2 페이지 개선 - 전화번호 변경 버튼 삭제, 더 명확한 안내 문구로 대체

### 📸 스크린샷 (선택)
<img width="281" height="614" alt="image" src="https://github.com/user-attachments/assets/bfc5ae19-8379-425d-97d9-ed4e242a3171" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 로그아웃 시 확인 모달과 토스트 알림이 추가되어 더 안전하게 로그아웃할 수 있습니다.
  * 로그인 상태에서 로그인 페이지 접근 시, 일반 사용자는 홈으로, 관리자는 관리자 대시보드로 자동 이동됩니다.

* **버그 수정**
  * "번호가 다르면 마이페이지에서" 안내 문구가 "개인정보가 다르면 마이페이지에서"로 변경되었습니다.

* **기능 개선**
  * 필터에서 "평판" 필터가 제거되어 더 간결해졌습니다.
  * 필터 및 카드 컴포넌트의 레이아웃과 스타일이 개선되어 반응형 및 가독성이 향상되었습니다.
  * 메인 콘텐츠 영역의 높이 계산이 네비게이션 표시 여부에 따라 더 정확하게 조절됩니다.
  * 헤더가 단순화되고, 사용자 정보와 로고만 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->