### PR TITLE
UF-345 QA 2차 수정 0731-v2

### DIFF
--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 
 import { sellAPI } from '@/api';
-import { ScrollToTopButton } from '@/features/common/components/ScrollToTopButton';
 import { ExchangeHeader } from '@/features/exchange/components/ExchangeHeader';
 import { ExchangeList } from '@/features/exchange/components/ExchangeList';
 import { useScrollTracker } from '@/hooks/useScrollTracker';
@@ -101,9 +100,6 @@ export default function ExchangePage() {
           <ExchangeHeader />
         </div>
 
-        {/* 필터 & 일괄구매 */}
-        {/* <ExchangeFilters /> */}
-
         {/* 게시글 목록 */}
         <ExchangeList
           onEdit={handleEdit}
@@ -111,11 +107,6 @@ export default function ExchangePage() {
           onReport={handleReport}
           onPurchase={handlePurchase}
         />
-
-        {/* Scroll To Top 버튼 */}
-        <div className="justify-end flex">
-          <ScrollToTopButton />
-        </div>
       </div>
 
       {/* 삭제 확인 모달 */}

--- a/src/features/common/components/ScrollToTopButton.tsx
+++ b/src/features/common/components/ScrollToTopButton.tsx
@@ -1,14 +1,19 @@
+// src/features/common/components/ScrollToTopButton.tsx
 import { useScrollToTop } from '@/hooks/useScrollToTop';
 import { Icon } from '@/shared';
 
 export const ScrollToTopButton = () => {
-  const { show, scrollToTop } = useScrollToTop();
+  const { show, scrollToTop } = useScrollToTop(200);
 
   if (!show) return null;
 
   return (
-    <div className="fixed bottom-20 z-50 w-10 h-10 flex items-center justify-center bg-primary-300 p-1 hover:bg-white/10 rounded-full cursor-pointer">
-      <Icon name="ArrowUp" className="w-5 h-5" color="white" onClick={scrollToTop} />
-    </div>
+    <button
+      onClick={scrollToTop}
+      className="w-12 h-12 flex items-center justify-center bg-primary-400/90 hover:bg-primary-400 rounded-full cursor-pointer shadow-lg transition-all duration-200 hover:scale-110 backdrop-blur-sm"
+      aria-label="맨 위로 스크롤"
+    >
+      <Icon name="ArrowUp" className="w-6 h-6" color="white" />
+    </button>
   );
 };

--- a/src/features/common/components/ZetDisplay/ZetDisplay.tsx
+++ b/src/features/common/components/ZetDisplay/ZetDisplay.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface ZetDisplayProps {
+  amount: number;
+  className?: string;
+  showUnit?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export const formatZetAmount = (amount: number): string => {
+  if (amount >= 99999) {
+    return '99,999+';
+  }
+  return amount.toLocaleString();
+};
+
+export const ZetDisplay: React.FC<ZetDisplayProps> = ({
+  amount,
+  className = '',
+  showUnit = true,
+  size = 'md',
+}) => {
+  const sizeClasses = {
+    sm: 'text-sm',
+    md: 'text-base',
+    lg: 'text-lg',
+  };
+
+  const formattedAmount = formatZetAmount(amount);
+
+  return (
+    <span className={`${sizeClasses[size]} ${className}`}>
+      {formattedAmount}
+      {showUnit && <span className="ml-1">ZET</span>}
+    </span>
+  );
+};

--- a/src/features/common/components/ZetDisplay/index.ts
+++ b/src/features/common/components/ZetDisplay/index.ts
@@ -1,0 +1,1 @@
+export { ZetDisplay, formatZetAmount } from './ZetDisplay';

--- a/src/features/exchange/components/ExchangeList.tsx
+++ b/src/features/exchange/components/ExchangeList.tsx
@@ -6,7 +6,7 @@ import { useInView } from 'react-intersection-observer';
 import SellingItem from '@/features/exchange/components/SellingItem';
 import { useInfiniteExchangePosts } from '@/features/exchange/hooks/useInfiniteExchangePosts';
 import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
-import { Button } from '@/shared';
+import { Button, Skeleton } from '@/shared';
 import { formatTimeAgo } from '@/utils/formatTimeAgo';
 import { getMobileDataTypeDisplay } from '@/utils/mobileData';
 
@@ -88,6 +88,10 @@ export const ExchangeList = ({ onEdit, onDelete, onReport, onPurchase }: Exchang
   // 빈 상태
   if (sellingItems.length === 0) {
     return <ExchangeEmpty />;
+  }
+
+  if (isLoading) {
+    return <Skeleton />;
   }
 
   return (

--- a/src/features/mypage/components/SignalCard.tsx
+++ b/src/features/mypage/components/SignalCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { IMAGE_PATHS } from '@/constants/images';
+import { formatZetAmount } from '@/features/common/components/ZetDisplay';
 import { Avatar, Button, Progress } from '@/shared';
 
 interface SignalCardProps {
@@ -23,6 +24,7 @@ export default function SignalCard({
   maxData,
 }: SignalCardProps) {
   const router = useRouter();
+  const formattedZet = formatZetAmount(zetAmount);
 
   return (
     <div
@@ -32,12 +34,15 @@ export default function SignalCard({
         backgroundColor: 'var(--color-background-card)',
       }}
     >
-      <div className="text-center py-2">
-        <h2 className="heading-24-bold" style={{ color: 'var(--color-badge-hover-dark)' }}>
+      <div className="text-center py-2 px-2">
+        <h2
+          className="heading-20-bold sm:heading-24-bold"
+          style={{ color: 'var(--color-badge-hover-dark)' }}
+        >
           UPHONIAN SIGNAL CARD
         </h2>
         <p
-          className="caption-8-regular"
+          className="caption-8-regular sm:caption-10-regular"
           style={{
             color: 'var(--color-badge-hover-dark)',
             opacity: 0.6,
@@ -92,7 +97,7 @@ export default function SignalCard({
             <span>보유중인 ZET</span>
             <div className="flex justify-between items-center gap-1 sm:gap-2">
               <span className="body-14-bold sm:body-16-bold font-bold text-chart-4 truncate">
-                {zetAmount} ZET
+                {formattedZet} ZET
               </span>
               <Link href="/charge">
                 <button className="whitespace-nowrap caption-12-medium sm:body-14-medium rounded-md px-2 sm:px-4 py-1 sm:py-2 flex items-center justify-center exploration-button text-xs sm:text-sm">

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,13 +1,54 @@
-import { useScrollStore } from '@/stores/useScrollStore';
+// src/hooks/useScrollToTop.ts
+import { useState, useEffect, useCallback } from 'react';
 
-export const useScrollToTop = () => {
-  const y = useScrollStore((s) => s.y);
+export const useScrollToTop = (threshold: number = 300) => {
+  const [show, setShow] = useState(false);
 
-  const show = y > 200;
+  useEffect(() => {
+    const handleScroll = () => {
+      // window 스크롤과 main 컨테이너 스크롤 모두 체크
+      const windowScrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      const mainElement = document.querySelector('main');
+      const mainScrollTop = mainElement?.scrollTop || 0;
 
-  const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  };
+      // 둘 중 하나라도 threshold를 넘으면 버튼 표시
+      const shouldShow = windowScrollTop > threshold || mainScrollTop > threshold;
+      setShow(shouldShow);
+    };
+
+    // window와 main 엘리먼트 모두에 이벤트 리스너 추가
+    window.addEventListener('scroll', handleScroll);
+    const mainElement = document.querySelector('main');
+    if (mainElement) {
+      mainElement.addEventListener('scroll', handleScroll);
+    }
+
+    // 초기 상태 체크
+    handleScroll();
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (mainElement) {
+        mainElement.removeEventListener('scroll', handleScroll);
+      }
+    };
+  }, [threshold]);
+
+  const scrollToTop = useCallback(() => {
+    // main 엘리먼트가 있으면 해당 엘리먼트를, 없으면 window를 스크롤
+    const mainElement = document.querySelector('main');
+    if (mainElement && mainElement.scrollTop > 0) {
+      mainElement.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    } else {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    }
+  }, []);
 
   return { show, scrollToTop };
 };

--- a/src/provider/AppLayoutProvider.tsx
+++ b/src/provider/AppLayoutProvider.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import React from 'react';
 
 import { IMAGE_PATHS } from '@/constants/images';
+import { ScrollToTopButton } from '@/features/common/components/ScrollToTopButton';
 import BottomNav from '@/shared/layout/BottomNav';
 import TopNav from '@/shared/layout/TopNav';
 
@@ -80,6 +81,12 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
           {children}
         </main>
         {!isNavigationHidden && <BottomNav />}
+
+        {!isNavigationHidden && (
+          <div className="absolute bottom-24 right-4 z-50">
+            <ScrollToTopButton />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/provider/AppLayoutProvider.tsx
+++ b/src/provider/AppLayoutProvider.tsx
@@ -65,7 +65,7 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
       >
         {!isNavigationHidden && <TopNav />}
         <main
-          className="overflow-y-auto overflow-x-hidden hide-scrollbar relative z-10 sm:px-10.5 px-6 text-white"
+          className="overflow-y-auto overflow-x-hidden hide-scrollbar relative z-10 sm:px-10.5 px-6 text-white flex flex-col justify-center items-center"
           style={{
             minHeight: '100dvh',
             paddingTop: isNavigationHidden ? '0px' : `${NAV_HEIGHT}px`,

--- a/src/shared/layout/TopNav/TopNav.tsx
+++ b/src/shared/layout/TopNav/TopNav.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { notificationsAPI } from '@/api/services/notification/notifications';
 import { NotificationItem } from '@/api/types/notification';
 import { ICON_PATHS } from '@/constants/icons';
+import { formatZetAmount } from '@/features/common/components/ZetDisplay';
 import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
 import { Icon, NotificationDropdown } from '@/shared';
 
@@ -24,7 +25,7 @@ const TopNav: React.FC<TopNavProps> = ({ title = 'UFO-Fi', onNotificationClick }
   const [notifications, setNotifications] = useState<NotificationItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
-  // 알림 데이터 로드 함수 추가
+  // 알림 데이터 로드 함수
   const loadNotifications = async () => {
     setIsLoading(true);
     try {
@@ -63,6 +64,7 @@ const TopNav: React.FC<TopNavProps> = ({ title = 'UFO-Fi', onNotificationClick }
   };
 
   const zetAsset = myInfo?.zetAsset ?? 0;
+  const formattedZet = formatZetAmount(zetAsset);
 
   return (
     <header className="fixed top-0 left-1/2 transform -translate-x-1/2 h-14 z-30 w-full min-w-[375px] max-w-[620px] bg-primary-700 shadow-sm">
@@ -91,7 +93,7 @@ const TopNav: React.FC<TopNavProps> = ({ title = 'UFO-Fi', onNotificationClick }
             >
               <div className="flex items-center overflow-hidden">
                 <span className="body-16-bold text-cyan-400 truncate max-w-[84px]">
-                  {zetAsset.toLocaleString()}
+                  {formattedZet}
                 </span>
                 <span className="body-16-bold text-cyan-400 ml-1">ZET</span>
               </div>


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #404 

### 🔎 작업 내용

**ScrollToTopButton 개선**

- [x] AppLayoutProvider 내에서 관리 (전역 관리로 변경)
- [x]  컨테이너 내 위치 고정: fixed → absolute로 변경하여 375px-620px 범위 내에서만 동작
- [x]  스크롤 감지 개선: main 엘리먼트와 window 스크롤 모두 감지하도록 수정
- [x]  threshold 최적화: 300px → 200px로 조정하여 더 빠른 버튼 표시

**ZET 표기 통일**
- [x] 공통 컴포넌트 생성: ZetDisplay 컴포넌트 및 formatZetAmount 유틸 함수 구현
- [x] 99,999+ 포맷 적용: TopNav, SignalCard 등 주요 화면에 통일된 ZET 표기 방식 적용

**AppLayoutProvider 전역에서 메인 영역만 중앙정렬로 수정**

### 📸 스크린샷 (선택)
<img width="281" height="81" alt="image" src="https://github.com/user-attachments/assets/18df74da-2906-4b00-9fbe-9f795a5838d6" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * ZET 금액을 포맷하여 표시하는 ZetDisplay 컴포넌트가 추가되었습니다.

* **버그 수정**
  * ZET 금액 표시가 더 깔끔하게 포맷되어 보여집니다(TopNav, SignalCard 등에서 적용).

* **UI/UX 개선**
  * 스크롤 맨 위로 이동 버튼이 접근성을 고려한 버튼 형태로 개선되고, 스타일과 애니메이션 효과가 향상되었습니다.
  * 스크롤 맨 위로 이동 버튼의 위치가 앱 레이아웃 내에서 하단 우측으로 변경되었습니다.
  * ExchangeList에서 로딩 시 Skeleton UI가 추가되어 더 자연스러운 로딩 경험을 제공합니다.
  * 일부 카드 및 텍스트의 스타일이 개선되었습니다.

* **리팩터링**
  * 스크롤 위치 감지 및 이동 로직이 개선되어 더 부드럽고 안정적으로 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->