### PR TITLE
UF-346 회원가입 되도록 임시 조치

### DIFF
--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { useUserRole } from '@/features/signup/hooks/useUserRole';
+import { useSignupStore } from '@/stores/useSignupStore';
+
+export default function SignupLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { isProfileComplete } = useSignupStore();
+  const { userRole, isLoading } = useUserRole();
+
+  useEffect(() => {
+    if (pathname === '/signup/plan' && !isProfileComplete()) {
+      router.replace('/signup/profile');
+    }
+  }, [pathname, isProfileComplete, router]);
+
+  useEffect(() => {
+    if (!isLoading && userRole === 'ROLE_USER') {
+      router.replace('/');
+    }
+  }, [userRole, isLoading, router]);
+
+  return <div className="flex flex-col w-full min-h-full">{children}</div>;
+}

--- a/src/app/signup/plan/page.tsx
+++ b/src/app/signup/plan/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import '@/styles/globals.css';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
-import { Plan, signupAPI } from '@/api';
+import { getUserInfoResponse, Plan, signupAPI } from '@/api';
 import { Carrier } from '@/api/types/carrier';
 import { OCRInputSection, Stepper } from '@/features/signup/components';
 import { signupPlanSchema, SignupPlanSchema } from '@/schemas/signupSchema';
@@ -15,12 +15,12 @@ import { Button, Title } from '@/shared';
 import { useSignupStore } from '@/stores/useSignupStore';
 
 const PlanPage = () => {
-  const router = useRouter();
   const { name, phoneNumber, carrier, planName, setForm, isProfileComplete } = useSignupStore();
   const [plans, setPlans] = useState<Plan[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [maxData, setMaxData] = useState<number | null>(null);
   const [networkType, setNetworkType] = useState('');
+  const queryClient = useQueryClient();
 
   const {
     control,
@@ -69,7 +69,17 @@ const PlanPage = () => {
       });
       toast.success('회원가입이 완료되었습니다!');
       useSignupStore.getState().reset();
-      router.push('/');
+      queryClient.setQueryData(['userInfo'], (prev: getUserInfoResponse | undefined) => {
+        if (!prev) return prev;
+
+        return {
+          ...prev,
+          content: {
+            ...prev.content,
+            role: 'ROLE_USER',
+          },
+        };
+      });
     } catch (error) {
       console.error('회원가입 에러:', error);
       toast.error('회원가입 중 오류가 발생했습니다.');


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #405

### 🔎 작업 내용
1. 현재 ['userInfo'] 키로 저장된 데이터를 가져온다 (prev).
2. 만약 prev가 없다면 그대로 반환.
3. prev.content.role을 'ROLE_USER'로 바꿔서 다시 저장.
4. 그 결과, useUserInfo 훅을 쓰고 있는 컴포넌트들은 이 변경을 감지해서 자동으로 재렌더링됨.


- [x] 회원가입을 눌렀을 때 다시 회원가입 페이지로 이동하는 현상 수정

### 📸 스크린샷 (선택)

### 📢 전달사항
임시조치 하면서 signup 페이지의 style이 또 망가졌습니다 ..

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원가입 과정에서 사용자 상태에 따라 자동으로 페이지 이동이 이루어지는 레이아웃 도입.
* **개선 사항**
  * 회원가입 완료 시 홈으로 이동하는 대신, 사용자 정보 캐시를 즉시 업데이트하여 최신 상태를 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->