### PR TITLE
UF-348 ZET 가격 수정

### DIFF
--- a/src/constants/packages.ts
+++ b/src/constants/packages.ts
@@ -1,8 +1,8 @@
 export const PACKAGES = [
-  { id: 'A', zet: 180, price: 1800 },
-  { id: 'B', zet: 360, price: 3600 },
-  { id: 'C', zet: 360, price: 3600 },
-  { id: 'D', zet: 1200, price: 12000 },
+  { id: 'A', zet: 150, price: 1500 },
+  { id: 'B', zet: 350, price: 3500 },
+  { id: 'C', zet: 500, price: 5000 },
+  { id: 'D', zet: 1000, price: 10000 },
   { id: 'E', zet: 3000, price: 30000 },
 ] as const;
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #408 

### 🔎 작업 내용

- [x] ZET 패키지 A 가격 조정: 180ZET (1,800원) → 150ZET (1,500원)
- [x] ZET 패키지 B 가격 조정: 360ZET (3,600원) → 350ZET (3,500원)
- [x] ZET 패키지 C 가격 조정: 360ZET (3,600원) → 500ZET (5,000원)
- [x] ZET 패키지 D 가격 조정: 1,200ZET (12,000원) → 1,000ZET (10,000원)
- [x] ZET 패키지 E 가격 조정: 3,000ZET (30,000원) → 3,000ZET (30,000원) (변경 없음)

### 📸 스크린샷 (선택)

### 📢 전달사항
- ZET 패키지 가격을 사용자 친화적으로 조정했습니다
- 패키지 C의 경우 ZET 수량을 증가시켜 더 매력적인 옵션으로 변경했습니다
- 패키지 A, B, D는 가격을 낮춰 진입 장벽을 낮췄습니다
- 패키지 E는 기존 가격을 유지하여 프리미엄 옵션으로 포지셔닝했습니다

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 패키지 A, B, C, D의 ZET 및 가격이 변경되었습니다.  
    - A: ZET 150, 가격 1,500  
    - B: ZET 350, 가격 3,500  
    - C: ZET 500, 가격 5,000  
    - D: ZET 1,000, 가격 10,000  
  * 패키지 E는 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->