### PR TITLE
UF-368 전역 Provider 구조 개선 및 글로벌 폰트 설정 업데이트

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,8 @@
-import { Analytics } from '@vercel/analytics/react';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 
 import '../styles/globals.css';
-import { TOAST_CONFIG } from '@/constants';
-import {
-  ModalProvider,
-  QueryProvider,
-  ViewportObserverProvider,
-  AppLayoutProvider,
-  AuthProvider,
-} from '@/provider';
-import { Toaster } from '@/shared';
-import AnalyticsProvider from '@/shared/components/Analytics';
-import FCMProvider from '@/shared/components/FCMProvider';
+import Providers from './providers';
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
@@ -46,21 +35,7 @@ export default function RootLayout({
           } as React.CSSProperties
         }
       >
-        <AnalyticsProvider />
-        <QueryProvider>
-          <ViewportObserverProvider>
-            <AppLayoutProvider>
-              <AuthProvider>
-                <FCMProvider>
-                  {children}
-                  <Analytics />
-                </FCMProvider>
-              </AuthProvider>
-            </AppLayoutProvider>
-            <ModalProvider />
-          </ViewportObserverProvider>
-        </QueryProvider>
-        <Toaster style={{ bottom: TOAST_CONFIG.BOTTOM_OFFSET }} />
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
         <meta name="format-detection" content="telephone=no" />
       </head>
       <body
-        className={`${pretendard.variable} antialiased min-h-screen bg-transparent`}
+        className={`${pretendard.className} antialiased min-h-screen bg-transparent`}
         style={
           {
             '--font-pyeongchangpeace-bold': 'PyeongChangPeace-Bold',

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Analytics } from '@vercel/analytics/react';
+
+import {
+  ModalProvider,
+  QueryProvider,
+  ViewportObserverProvider,
+  AppLayoutProvider,
+  AuthProvider,
+  FCMProvider,
+  ToastProvider,
+  AnalyticsProvider,
+} from '@/provider';
+
+interface ProvidersProps {
+  children: React.ReactNode;
+}
+
+/**
+ * 전역 Provider들을 통합 관리하는 컴포넌트
+ * - 모든 전역 상태 관리자들을 계층적으로 구성
+ */
+export default function Providers({ children }: ProvidersProps) {
+  return (
+    <>
+      <AnalyticsProvider />
+      <QueryProvider>
+        <ViewportObserverProvider>
+          <AppLayoutProvider>
+            <AuthProvider>
+              <FCMProvider>
+                <ToastProvider>
+                  {children}
+                  <Analytics />
+                </ToastProvider>
+              </FCMProvider>
+            </AuthProvider>
+          </AppLayoutProvider>
+          <ModalProvider />
+        </ViewportObserverProvider>
+      </QueryProvider>
+    </>
+  );
+}

--- a/src/provider/AnalyticsProvider.tsx
+++ b/src/provider/AnalyticsProvider.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID || '';
 const CLARITY_ID = process.env.NEXT_PUBLIC_CLARITY_ID || '';
 
-export default function Analytics() {
+export function AnalyticsProvider() {
   // Clarity 초기화
   useEffect(() => {
     if (CLARITY_ID) {

--- a/src/provider/FCMProvider.tsx
+++ b/src/provider/FCMProvider.tsx
@@ -8,7 +8,7 @@ interface FCMProviderProps {
   children: React.ReactNode;
 }
 
-export default function FCMProvider({ children }: FCMProviderProps) {
+export function FCMProvider({ children }: FCMProviderProps) {
   useEffect(() => {
     setupMessageListener();
   }, []);

--- a/src/provider/ToastProvider.tsx
+++ b/src/provider/ToastProvider.tsx
@@ -11,7 +11,7 @@ export function ToastProvider({ children }: ToastProviderProps) {
   return (
     <>
       {children}
-      <Toaster className={`fixed bottom-[${TOAST_CONFIG.BOTTOM_OFFSET}px] z-[9999]`} />
+      <Toaster className={`fixed bottom-[${TOAST_CONFIG.BOTTOM_OFFSET}] z-[9999]`} />
     </>
   );
 }

--- a/src/provider/ToastProvider.tsx
+++ b/src/provider/ToastProvider.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { TOAST_CONFIG } from '@/constants';
+import { Toaster } from '@/shared';
+
+interface ToastProviderProps {
+  children: React.ReactNode;
+}
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  return (
+    <>
+      {children}
+      <Toaster className={`fixed bottom-[${TOAST_CONFIG.BOTTOM_OFFSET}px] z-[9999]`} />
+    </>
+  );
+}

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -3,3 +3,6 @@ export { QueryProvider } from './QueryProvider';
 export { ViewportObserverProvider } from './ViewportObserverProvider';
 export { AuthProvider } from './AuthProvider';
 export { AppLayoutProvider } from './AppLayoutProvider';
+export { FCMProvider } from './FCMProvider';
+export { ToastProvider } from './ToastProvider';
+export { AnalyticsProvider } from './AnalyticsProvider';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -265,7 +265,6 @@
 
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-family-sans);
     line-height: 1.6;
     overscroll-behavior: none;
     touch-action: manipulation;


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #432 

### 🔎 작업 내용

멘토님 피드백에 따라 전역 Provider 구조 개선 및 글로벌 폰트 설정을 Tailwind CSS에 맞게 변경했습니다!

- [x] providers.tsx 생성: 전역 Provider 분리
  - [x] Toaster, Analytics 등도 내부에서 통합 관리
  - [x] ToastProvier style 제거, Tailwind 전역 폰트 적용 (font-pretendard)
- [x] className={variable} 제거 → globals.css 기준으로 통일

### 📸 스크린샷 (선택)
<img width="526" height="468" alt="image" src="https://github.com/user-attachments/assets/84abbf24-e246-4fc9-b1c5-761b4d1d4641" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 여러 전역 컨텍스트 제공자와 컴포넌트를 하나의 Providers 컴포넌트로 통합하여 레이아웃 구조를 단순화했습니다.
  * Analytics, FCM, Toast 등 주요 제공자 컴포넌트들을 명명된 export 방식으로 변경했습니다.
  * 폰트 클래스 사용 방식을 변경했습니다.

* **New Features**
  * ToastProvider 컴포넌트를 추가하여 토스트 알림이 화면 하단에 고정되도록 개선했습니다.

* **Style**
  * body 요소의 font-family 선언을 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->