### PR TITLE
UF-369 getUserFromToken.ts로 토큰 확인 로직 분리

### DIFF
--- a/src/api/client/axios.ts
+++ b/src/api/client/axios.ts
@@ -119,10 +119,15 @@ axiosInstance.interceptors.response.use(
         processQueue(refreshError, null);
 
         if (typeof window !== 'undefined') {
-          document.cookie =
-            'Authorization=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict;';
-          document.cookie =
-            'Refresh=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict;';
+          /*
+              클라이언트에서 쿠키를 삭제해도 HttpOnly 쿠키는 제거되지 않음
+              → 브라우저는 같은 이름의 새 쿠키를 생성해 두 개를 따로 저장함 (중복 쿠키 문제 발생)
+          */
+          // document.cookie =
+          //   'Authorization=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict;';
+          // document.cookie =
+          //   'Refresh=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict;';
+
           toast.error('로그인이 만료되었습니다. 다시 로그인해주세요.');
           setTimeout(() => {
             window.location.href = '/login';

--- a/src/app/api/achievements/honor/select/route.ts
+++ b/src/app/api/achievements/honor/select/route.ts
@@ -1,36 +1,15 @@
-import jwt from 'jsonwebtoken';
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/prisma';
+import { getUserFromToken } from '@/utils/getUserFromToken';
 
 export async function POST(req: NextRequest) {
-  const token = (await cookies()).get('Authorization')?.value;
-  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-  if (!process.env.JWT_SECRET) {
-    throw new Error('JWT_SECRET 환경 변수가 설정되지 않았습니다.');
+  const result = await getUserFromToken();
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
   }
 
-  let userId: bigint;
-  try {
-    const secret = Buffer.from(process.env.JWT_SECRET, 'base64');
-    const decoded = jwt.verify(token, secret) as jwt.JwtPayload;
-    const id = decoded.id ?? decoded.sub;
-    if (!id) {
-      throw new Error('토큰에 user ID가 없습니다.');
-    }
-    userId = BigInt(id);
-  } catch (error) {
-    if (error instanceof jwt.TokenExpiredError) {
-      return NextResponse.json({ error: '토큰이 만료되었습니다.' }, { status: 401 });
-    } else if (error instanceof jwt.JsonWebTokenError) {
-      return NextResponse.json({ error: '토큰이 유효하지 않습니다.' }, { status: 401 });
-    } else {
-      console.error('Token processing error:', error);
-      return NextResponse.json({ error: '인증에 실패했습니다.' }, { status: 401 });
-    }
-  }
+  const { userId } = result;
 
   let body: { name?: string };
   try {

--- a/src/app/api/collections/search/route.ts
+++ b/src/app/api/collections/search/route.ts
@@ -1,8 +1,7 @@
-import jwt from 'jsonwebtoken';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/prisma';
+import { getUserFromToken } from '@/utils/getUserFromToken';
 
 type QdrantPayload = {
   id: number;
@@ -23,25 +22,15 @@ type QdrantResponse = {
 
 export async function GET() {
   // STEP 1. 쿠키에서 JWT 토큰 추출 (로그인 여부 확인)
-  // - 로그인한 사용자인지 판단하기 위해 Authorization 쿠키 확인
-  const token = (await cookies()).get('Authorization')?.value;
-  if (!token) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const result = await getUserFromToken();
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
   }
 
-  // STEP 2. JWT 서명을 검증할 비밀 키가 설정되어 있는지 확인
-  if (!process.env.JWT_SECRET) {
-    throw new Error('JWT_SECRET is not configured');
-  }
+  const { userId } = result;
 
   try {
-    // STEP 3. JWT 토큰 디코딩 → 유저 ID 추출
-    // - payload에서 id 또는 sub 필드를 기준으로 사용자 식별
-    const secret = Buffer.from(process.env.JWT_SECRET!, 'base64');
-    const decoded = jwt.verify(token, secret) as jwt.JwtPayload;
-    const userId = decoded.id ?? decoded.sub;
-
-    // STEP 4. 해당 유저의 기본 정보 및 요금제 정보 조회
+    // STEP 2. 해당 유저의 기본 정보 및 요금제 정보 조회
     // - 필터링 조건을 생성하기 위한 통신사, 데이터유형 등 확보 목적
     const baseUser = await prisma.users.findUnique({
       where: { id: Number(userId) },
@@ -53,7 +42,7 @@ export async function GET() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    // STEP 5. 최근 거래 이력을 통해 해당 유저의 거래 성향 분석
+    // STEP 3. 최근 거래 이력을 통해 해당 유저의 거래 성향 분석
     // - 판매가 많으면 'seller', 구매가 많으면 'purchaser'로 분류
     const trades = await prisma.trade_histories.findMany({
       where: {
@@ -67,7 +56,7 @@ export async function GET() {
     const type = sales >= purchases ? 'seller' : 'purchaser';
     const oppositeType = type === 'seller' ? 'purchaser' : 'seller';
 
-    // STEP 6. 사용자가 보유한 요금제 기반으로 가장 많이 이용한 통신사(carrier) 산출
+    // STEP 4. 사용자가 보유한 요금제 기반으로 가장 많이 이용한 통신사(carrier) 산출
     // - 다수 요금제 중 가장 빈도 높은 통신사를 추천 기준에 반영
     const rawPlans = baseUser.user_plans;
     const userPlans = Array.isArray(rawPlans) ? rawPlans : [];
@@ -78,7 +67,7 @@ export async function GET() {
         (a, b) => carriers.filter((v) => v === b).length - carriers.filter((v) => v === a).length,
       )[0] ?? '';
 
-    // STEP 7. 사용자가 주로 이용한 데이터 유형(mobile_data_type) 파악
+    // STEP 5. 사용자가 주로 이용한 데이터 유형(mobile_data_type) 파악
     // - LTE, 5G 등 유사 이용자군 추천을 위한 참고값
     const types = userPlans.map((p) => p.plans?.mobile_data_type).filter((t): t is string => !!t);
     const mobile_data_type =
@@ -86,7 +75,7 @@ export async function GET() {
         (a, b) => types.filter((v) => v === b).length - types.filter((v) => v === a).length,
       )[0] ?? '';
 
-    // STEP 8. 이미 팔로우한 사용자는 추천에서 제외
+    // STEP 6. 이미 팔로우한 사용자는 추천에서 제외
     // - 유사한 사람만 보이도록 추천 대상 중복 방지
     const followedUsers = await prisma.follows.findMany({
       where: { follower_user_id: Number(userId) },
@@ -94,7 +83,7 @@ export async function GET() {
     });
     const followedIds = followedUsers.map((f) => Number(f.following_user_id));
 
-    // STEP 9. Qdrant Recommend API 요청
+    // STEP 7. Qdrant Recommend API 요청
     // - 기준 유저의 벡터를 기반으로 유사도가 높은 사용자 추천
     // - 조건: 일반 사용자만, 자기 자신 및 팔로우한 유저 제외
     // - 우선 순위 필터: 반대 거래유형, 동일 통신사, 동일 데이터유형
@@ -127,13 +116,13 @@ export async function GET() {
       }),
     });
 
-    // STEP 10. Qdrant API 요청 실패 시 상세 에러 로그 출력
+    // STEP 8. Qdrant API 요청 실패 시 상세 에러 로그 출력
     if (!res.ok) {
       const errorText = await res.text();
       throw new Error(`Qdrant request failed: ${res.status} ${res.statusText}\n${errorText}`);
     }
 
-    // STEP 11. 추천 결과 파싱 및 사용자 정보 매핑
+    // STEP 9. 추천 결과 파싱 및 사용자 정보 매핑
     // - score가 높을수록 유사도가 높은 사용자
     const data: QdrantResponse = await res.json();
     const neighbors = Array.isArray(data.result)
@@ -145,13 +134,13 @@ export async function GET() {
         }))
       : [];
 
-    // STEP 12. 최종 응답 반환 (추천 사용자 리스트)
+    // STEP 10. 최종 응답 반환 (추천 사용자 리스트)
     return NextResponse.json({
       neighbors,
       message: neighbors.length > 0 ? '추천 결과 반환 성공' : '추천 결과가 없습니다',
     });
   } catch (err) {
-    // STEP 13. 예외 발생 시 서버 에러 반환
+    // STEP 11. 예외 발생 시 서버 에러 반환
     console.error('Recommend failed:', err);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }

--- a/src/utils/getUserFromToken.ts
+++ b/src/utils/getUserFromToken.ts
@@ -1,0 +1,31 @@
+import jwt from 'jsonwebtoken';
+import { cookies } from 'next/headers';
+
+export async function getUserFromToken() {
+  const token = (await cookies()).get('Authorization')?.value;
+  if (!token) {
+    return { error: 'Unauthorized', status: 401 as const };
+  }
+
+  if (!process.env.JWT_SECRET) {
+    throw new Error('JWT_SECRET 환경 변수가 설정되지 않았습니다.');
+  }
+
+  try {
+    const secret = Buffer.from(process.env.JWT_SECRET, 'base64');
+    const decoded = jwt.verify(token, secret) as jwt.JwtPayload;
+    const id = decoded.id ?? decoded.sub;
+    if (!id) throw new Error('토큰에 user ID가 없습니다.');
+
+    return { userId: BigInt(id) };
+  } catch (error) {
+    if (error instanceof jwt.TokenExpiredError) {
+      return { error: '토큰이 만료되었습니다.', status: 401 as const };
+    } else if (error instanceof jwt.JsonWebTokenError) {
+      return { error: '토큰이 유효하지 않습니다.', status: 401 as const };
+    } else {
+      console.error('Token processing error:', error);
+      return { error: '인증에 실패했습니다.', status: 401 as const };
+    }
+  }
+}

--- a/src/utils/getUserFromToken.ts
+++ b/src/utils/getUserFromToken.ts
@@ -4,18 +4,20 @@ import { cookies } from 'next/headers';
 export async function getUserFromToken() {
   const token = (await cookies()).get('Authorization')?.value;
   if (!token) {
-    return { error: 'Unauthorized', status: 401 as const };
+    return { error: '인증 토큰이 없습니다.', status: 401 as const };
   }
 
   if (!process.env.JWT_SECRET) {
-    throw new Error('JWT_SECRET 환경 변수가 설정되지 않았습니다.');
+    return { error: 'JWT_SECRET 환경 변수가 설정되지 않았습니다.', status: 500 as const };
   }
 
   try {
     const secret = Buffer.from(process.env.JWT_SECRET, 'base64');
     const decoded = jwt.verify(token, secret) as jwt.JwtPayload;
     const id = decoded.id ?? decoded.sub;
-    if (!id) throw new Error('토큰에 user ID가 없습니다.');
+    if (!id) {
+      return { error: '토큰에 유효한 사용자 ID가 없습니다.', status: 401 as const };
+    }
 
     return { userId: BigInt(id) };
   } catch (error) {


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #433

### 🔎 작업 내용

- [x] getUserFromToken.ts로 토큰을 통해 userId를 가져오는 로직 분리

### 📸 스크린샷 (선택)

### 📢 전달사항
각 API의 모듈화 및 분리 필요

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **Refactor**
  * 인증 로직을 중앙화하여 JWT 토큰 처리 및 사용자 추출을 별도의 유틸리티 함수로 분리하였습니다. 여러 API 엔드포인트에서 인증 관련 중복 코드를 제거하고, 에러 메시지 및 상태 코드 처리를 일관되게 개선하였습니다.
  * 일부 엔드포인트에서 에러 핸들링과 응답 코드가 더 명확하게 처리됩니다.
  * 편지 API에서 최대 단계 제한, BFS 경로 탐색, OpenAI API 호출 시 에러 처리 및 응답 상태 코드가 개선되었습니다.

* **Bug Fixes**
  * HttpOnly 쿠키 삭제 시 발생하던 중복 쿠키 문제에 대한 안내 주석이 추가되었습니다.

* **New Features**
  * JWT 토큰에서 사용자 정보를 추출하는 유틸리티 함수가 새롭게 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->