### PR TITLE
UF-349 AdminSideMenu 리팩토링

### DIFF
--- a/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
+++ b/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
@@ -64,6 +64,32 @@ const menuItems: MenuItem[] = [
   },
 ];
 
+// 스타일 맵 객체들
+const menuItemStyleMap = {
+  active: 'bg-blue-50 text-blue-700 border-l-4 border-blue-700',
+  inactive: 'text-gray-700 hover:bg-gray-50 hover:text-gray-900',
+};
+
+const iconColorMap = {
+  active: 'text-blue-700',
+  inactive: 'text-gray-500 group-hover:text-gray-700',
+};
+
+const chevronColorMap = {
+  active: 'text-blue-700',
+  inactive: 'text-gray-400 group-hover:text-gray-600',
+};
+
+const overlayStyleMap = {
+  closing: 'bg-black/0',
+  open: 'bg-black/40',
+};
+
+const navStyleMap = {
+  closing: 'transform translate-x-full',
+  open: 'transform translate-x-0',
+};
+
 type AdminSideMenuProps = ComponentProps<'div'>;
 
 export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
@@ -156,16 +182,14 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
             <Link
               href={item.href}
               className={`flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200 group ${
-                isActive
-                  ? 'bg-blue-50 text-blue-700 border-l-4 border-blue-700'
-                  : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
+                isActive ? menuItemStyleMap.active : menuItemStyleMap.inactive
               } ${level > 0 ? 'ml-6 py-2' : ''}`}
               onClick={handleClose}
             >
               <Icon
                 name={item.icon}
                 className={`w-5 h-5 transition-colors ${
-                  isActive ? 'text-blue-700' : 'text-gray-500 group-hover:text-gray-700'
+                  isActive ? iconColorMap.active : iconColorMap.inactive
                 }`}
               />
               <span className="flex-1">{item.label}</span>
@@ -174,15 +198,13 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
             <button
               onClick={() => hasChildren && toggleMenu(item.id)}
               className={`flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200 w-full group ${
-                isActive
-                  ? 'bg-blue-50 text-blue-700'
-                  : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
+                isActive ? menuItemStyleMap.active : menuItemStyleMap.inactive
               }`}
             >
               <Icon
                 name={item.icon}
                 className={`w-5 h-5 transition-colors ${
-                  isActive ? 'text-blue-700' : 'text-gray-500 group-hover:text-gray-700'
+                  isActive ? iconColorMap.active : iconColorMap.inactive
                 }`}
               />
               <span className="flex-1 text-left">{item.label}</span>
@@ -190,7 +212,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
                 <Icon
                   name={isOpen ? 'ChevronUp' : 'ChevronDown'}
                   className={`w-4 h-4 transition-all duration-200 ${
-                    isActive ? 'text-blue-700' : 'text-gray-400 group-hover:text-gray-600'
+                    isActive ? chevronColorMap.active : chevronColorMap.inactive
                   }`}
                 />
               )}
@@ -235,7 +257,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
       {(open || isClosing) && (
         <div
           className={`fixed inset-0 z-[9998] flex transition-opacity duration-200 ${
-            isClosing ? 'bg-black/0' : 'bg-black/40'
+            isClosing ? overlayStyleMap.closing : overlayStyleMap.open
           }`}
           role="dialog"
           aria-modal="true"
@@ -246,7 +268,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
           <nav
             ref={menuRef}
             className={`w-72 bg-white h-full flex flex-col shadow-lg transition-transform duration-200 ease-out ${
-              isClosing ? 'transform translate-x-full' : 'transform translate-x-0'
+              isClosing ? navStyleMap.closing : navStyleMap.open
             } ${open && !isClosing ? 'animate-slide-in-right' : ''}`}
             role="navigation"
             aria-label="관리자 메뉴"

--- a/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
+++ b/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
@@ -188,7 +188,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
             >
               <Icon
                 name={item.icon}
-                className={`w-5 h-5 transition-colors ${
+                className={` size-5 transition-colors ${
                   isActive ? iconColorMap.active : iconColorMap.inactive
                 }`}
               />
@@ -203,7 +203,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
             >
               <Icon
                 name={item.icon}
-                className={`w-5 h-5 transition-colors ${
+                className={`size-5 transition-colors ${
                   isActive ? iconColorMap.active : iconColorMap.inactive
                 }`}
               />
@@ -250,7 +250,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
         onClick={handleOpen}
         aria-label="메뉴 열기"
       >
-        <Icon name="Menu" className="w-5 h-5 text-gray-700" />
+        <Icon name="Menu" className="size-5 text-gray-700" />
       </button>
 
       {/* 오버레이 메뉴 (모바일/테블릿) */}
@@ -303,7 +303,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
               >
                 <Icon
                   name="HelpCircle"
-                  className="w-5 h-5 text-gray-500 group-hover:text-gray-700"
+                  className="size-5 text-gray-500 group-hover:text-gray-700"
                 />
                 <span>도움말</span>
               </Link>

--- a/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
+++ b/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
@@ -66,7 +66,7 @@ const menuItems: MenuItem[] = [
 
 type AdminSideMenuProps = ComponentProps<'div'>;
 
-export const AdminSideMenu: React.FC<AdminSideMenuProps> = ({ className }) => {
+export const AdminSideMenu: React.FC<AdminSideMenuProps> = ({ className, ...rest }) => {
   const [open, setOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
   const [openMenus, setOpenMenus] = useState<Set<string>>(new Set());
@@ -220,7 +220,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = ({ className }) => {
   }, [renderMenuItem]);
 
   return (
-    <>
+    <div {...rest}>
       {/* 햄버거 버튼 - 테블릿 이하에서 표시 */}
       <button
         className={`lg:hidden p-2 hover:bg-gray-100 transition-colors rounded flex items-center justify-center ${className || ''}`}
@@ -301,6 +301,6 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = ({ className }) => {
           animation: slide-in-right 0.2s ease-out;
         }
       `}</style>
-    </>
+    </div>
   );
 };

--- a/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
+++ b/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef, ComponentProps } from 'react';
 
 import { Icon } from '@/shared';
 import type { IconType } from '@/shared';
@@ -64,9 +64,7 @@ const menuItems: MenuItem[] = [
   },
 ];
 
-interface AdminSideMenuProps {
-  className?: string;
-}
+type AdminSideMenuProps = ComponentProps<'div'>;
 
 export const AdminSideMenu: React.FC<AdminSideMenuProps> = ({ className }) => {
   const [open, setOpen] = useState(false);

--- a/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
+++ b/src/shared/ui/AdminSideMenu/AdminSideMenu.tsx
@@ -66,7 +66,8 @@ const menuItems: MenuItem[] = [
 
 type AdminSideMenuProps = ComponentProps<'div'>;
 
-export const AdminSideMenu: React.FC<AdminSideMenuProps> = ({ className, ...rest }) => {
+export const AdminSideMenu: React.FC<AdminSideMenuProps> = (props) => {
+  const { className } = props;
   const [open, setOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
   const [openMenus, setOpenMenus] = useState<Set<string>>(new Set());
@@ -162,7 +163,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = ({ className, ...rest
               onClick={handleClose}
             >
               <Icon
-                name={item.icon as IconType}
+                name={item.icon}
                 className={`w-5 h-5 transition-colors ${
                   isActive ? 'text-blue-700' : 'text-gray-500 group-hover:text-gray-700'
                 }`}
@@ -179,7 +180,7 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = ({ className, ...rest
               }`}
             >
               <Icon
-                name={item.icon as IconType}
+                name={item.icon}
                 className={`w-5 h-5 transition-colors ${
                   isActive ? 'text-blue-700' : 'text-gray-500 group-hover:text-gray-700'
                 }`}
@@ -220,10 +221,10 @@ export const AdminSideMenu: React.FC<AdminSideMenuProps> = ({ className, ...rest
   }, [renderMenuItem]);
 
   return (
-    <div {...rest}>
+    <div {...props}>
       {/* 햄버거 버튼 - 테블릿 이하에서 표시 */}
       <button
-        className={`lg:hidden p-2 hover:bg-gray-100 transition-colors rounded flex items-center justify-center ${className || ''}`}
+        className={`lg:hidden p-2 hover:bg-gray-100 transition-colors rounded flex items-center justify-center ${className ?? ''}`}
         onClick={handleOpen}
         aria-label="메뉴 열기"
       >


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #412 
### 🔎 작업 내용

- [x] AdminSideMenu 컴포넌트의 props 타입을 ComponentProps<div>로 변경
- [x] className 외에도 onClick, style, data-, aria- 등 모든 HTML 속성 지원
- [x] 컴포넌트 최상위 요소를 Fragment에서 div로 변경하여 props 전달 가능
- [x] props 전달 방식을 사용자 요청 패턴으로 최적화 (props) => { const { className } = props; }
- [x] 전체 props를 <div {...props}>로 한 번에 전달하여 최대 확장성 확보
- [x] className 처리 방식을 nullish coalescing (??)으로 개선
- [x] 불필요한 타입 캐스팅 제거로 타입 안전성 향상

### 📸 스크린샷 (선택)

### 📢 전달사항
1. 확장성 대폭 향상: ComponentProps<'div'> 적용으로 HTML div 요소의 모든 속성을 자동 지원
2. 타입 안전성 강화: TypeScript가 모든 유효한 HTML 속성을 컴파일 타임에 체크
3. 유지보수성 개선: 새로운 props 추가 시 컴포넌트 수정 불필요, 스프레드 연산자로 간결한 코드
4. 개발자 경험 향상: IDE 자동완성 지원, 모든 HTML 속성에 대한 타입 힌트 제공

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * AdminSideMenu 컴포넌트가 더 다양한 div 속성을 지원하도록 개선되었습니다.  
  * className 처리 방식이 개선되어, 사용자 정의 스타일 적용이 더욱 유연해졌습니다.
  * 메뉴 아이템과 아이콘 등 스타일 관리가 중앙화되어 일관성 있고 유지보수가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->