### PR TITLE
UF-351 Title 리팩토링

### DIFF
--- a/src/shared/ui/Title/Title.tsx
+++ b/src/shared/ui/Title/Title.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
 import { cn } from '@/lib/utils';
 
 import { Icon } from '../Icons';
-import type { TitleProps, TitleIconVariant } from './Title.types';
+import type { TitleIconVariant } from './Title.types';
 
 type IconType = 'ChevronLeft' | 'X';
 
@@ -19,6 +19,12 @@ const getIconName = (variant: TitleIconVariant | undefined): IconType | null => 
     default:
       return null;
   }
+};
+
+type TitleProps = ComponentProps<'div'> & {
+  title: string;
+  iconVariant?: TitleIconVariant;
+  onIconClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
 export const Title: React.FC<TitleProps> = (props) => {

--- a/src/shared/ui/Title/Title.tsx
+++ b/src/shared/ui/Title/Title.tsx
@@ -22,38 +22,40 @@ const getIconName = (variant: TitleIconVariant | undefined): IconType | null => 
 };
 
 export const Title: React.FC<TitleProps> = (props) => {
+  const { title, iconVariant = 'none', onIconClick, className, ...rest } = props;
+
   const router = useRouter();
-  const iconName = getIconName(props.iconVariant);
+  const iconName = getIconName(iconVariant);
   const hasIcon = iconName !== null;
 
   // 아이콘 클릭 핸들러
   const handleClick = React.useCallback(
     (e: React.MouseEvent<HTMLButtonElement>): void => {
-      if (props.onIconClick) {
-        props.onIconClick(e);
-      } else if (props.iconVariant === 'back') {
+      if (onIconClick) {
+        onIconClick(e);
+      } else if (iconVariant === 'back') {
         router.back();
       }
     },
-    [props.onIconClick, props.iconVariant, router],
+    [onIconClick, iconVariant, router],
   );
 
   return (
-    <div className={cn('relative w-full flex items-center py-4 px-4', props.className)} {...props}>
+    <div className={cn('relative w-full flex items-center py-4 px-4', className)} {...rest}>
       {/* 아이콘 영역 */}
       {hasIcon && (
         <button
           type="button"
           onClick={handleClick}
           className="absolute left-4 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors"
-          aria-label={`${props.iconVariant} 버튼`}
+          aria-label={`${iconVariant} 버튼`}
         >
           <Icon name={iconName} size="md" color="white" className="w-6 h-6 text-white" />
         </button>
       )}
 
       {/* 타이틀 영역 */}
-      <h1 className={cn('body-20-bold text-white', 'w-full text-center')}>{props.title}</h1>
+      <h1 className={cn('body-20-bold text-white', 'w-full text-center')}>{title}</h1>
     </div>
   );
 };

--- a/src/shared/ui/Title/Title.tsx
+++ b/src/shared/ui/Title/Title.tsx
@@ -21,45 +21,39 @@ const getIconName = (variant: TitleIconVariant | undefined): IconType | null => 
   }
 };
 
-export const Title: React.FC<TitleProps> = ({
-  title,
-  iconVariant = 'none',
-  onIconClick,
-  className,
-  ...props
-}) => {
+export const Title: React.FC<TitleProps> = (props) => {
   const router = useRouter();
-  const iconName = getIconName(iconVariant);
+  const iconName = getIconName(props.iconVariant);
   const hasIcon = iconName !== null;
 
   // 아이콘 클릭 핸들러
   const handleClick = React.useCallback(
     (e: React.MouseEvent<HTMLButtonElement>): void => {
-      if (onIconClick) {
-        onIconClick(e);
-      } else if (iconVariant === 'back') {
+      if (props.onIconClick) {
+        props.onIconClick(e);
+      } else if (props.iconVariant === 'back') {
         router.back();
       }
     },
-    [onIconClick, iconVariant, router],
+    [props.onIconClick, props.iconVariant, router],
   );
 
   return (
-    <div className={cn('relative w-full flex items-center py-4 px-4', className)} {...props}>
+    <div className={cn('relative w-full flex items-center py-4 px-4', props.className)} {...props}>
       {/* 아이콘 영역 */}
       {hasIcon && (
         <button
           type="button"
           onClick={handleClick}
           className="absolute left-4 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors"
-          aria-label={`${iconVariant} 버튼`}
+          aria-label={`${props.iconVariant} 버튼`}
         >
           <Icon name={iconName} size="md" color="white" className="w-6 h-6 text-white" />
         </button>
       )}
 
       {/* 타이틀 영역 */}
-      <h1 className={cn('body-20-bold text-white', 'w-full text-center')}>{title}</h1>
+      <h1 className={cn('body-20-bold text-white', 'w-full text-center')}>{props.title}</h1>
     </div>
   );
 };

--- a/src/shared/ui/Title/Title.tsx
+++ b/src/shared/ui/Title/Title.tsx
@@ -22,13 +22,13 @@ const getIconName = (variant: TitleIconVariant | undefined): IconType | null => 
 };
 
 type TitleProps = ComponentProps<'div'> & {
-  title: string;
+  title?: string;
   iconVariant?: TitleIconVariant;
   onIconClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
 export const Title: React.FC<TitleProps> = (props) => {
-  const { title, iconVariant = 'none', onIconClick, className, ...rest } = props;
+  const { title = '제목', iconVariant = 'none', onIconClick, className, ...rest } = props;
 
   const router = useRouter();
   const iconName = getIconName(iconVariant);

--- a/src/shared/ui/Title/Title.tsx
+++ b/src/shared/ui/Title/Title.tsx
@@ -54,10 +54,10 @@ export const Title: React.FC<TitleProps> = (props) => {
         <button
           type="button"
           onClick={handleClick}
-          className="absolute left-4 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors"
+          className="absolute left-4 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center size-8 rounded-full hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/50 transition-colors"
           aria-label={`${iconVariant} 버튼`}
         >
-          <Icon name={iconName} size="md" color="white" className="w-6 h-6 text-white" />
+          <Icon name={iconName} size="md" color="white" className="size-6 text-white" />
         </button>
       )}
 

--- a/src/shared/ui/Title/Title.tsx
+++ b/src/shared/ui/Title/Title.tsx
@@ -10,15 +10,16 @@ import type { TitleIconVariant } from './Title.types';
 
 type IconType = 'ChevronLeft' | 'X';
 
+// 스타일 맵 객체들
+const iconVariantMap = {
+  back: 'ChevronLeft',
+  close: 'X',
+  none: null,
+} as const;
+
 const getIconName = (variant: TitleIconVariant | undefined): IconType | null => {
-  switch (variant) {
-    case 'back':
-      return 'ChevronLeft';
-    case 'close':
-      return 'X';
-    default:
-      return null;
-  }
+  if (!variant || variant === 'none') return null;
+  return iconVariantMap[variant] || null;
 };
 
 type TitleProps = ComponentProps<'div'> & {


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #414 

### 🔎 작업 내용
- [x] Title 컴포넌트의 props 구조 분해를 전체 props로 변경
- [x] 기본값 설정 및 props 구조 분해 최적화로 안전성 강화
- [x] ComponentProps<'div'> 적용으로 HTML div 요소의 모든 속성 자동 지원
- [x] 필수 props를 선택적으로 변경하여 사용 유연성 향상
- [x] 조건부 스타일링을 객체로 분리하여 가독성 및 유지보수성 향상

### 📸 스크린샷 (선택)

### 📢 전달사항
1. 코드 간결성 대폭 향상: 개별 props 구조 분해를 전체 props 객체로 변경하여 중복 코드 제거
2. 유지보수성 개선: props가 추가될 때마다 코드를 두 군데서 수정할 필요 없음
3. 확장성 강화: ComponentProps<'div'> 적용으로 HTML div 요소의 모든 속성 자동 지원
4. 타입 안전성 보장: TypeScript와 함께 사용할 때 모든 유효한 props를 컴파일 타임에 체크
5. 개발자 경험 향상: IDE 자동완성 지원 및 실수 가능성 최소화

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩터링**
  * 아이콘 매핑 방식을 개선하여 코드 가독성을 높였습니다.
  * 컴포넌트의 props 구조 분해 위치와 기본값 할당 방식을 변경했습니다.
  * 일부 클래스명을 더 간결한 유틸리티 클래스로 변경하여 스타일을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->