### PR TITLE
UF-353 SpeechBubble 리팩토링

### DIFF
--- a/src/shared/ui/SpeechBubble/SpeechBubble.tsx
+++ b/src/shared/ui/SpeechBubble/SpeechBubble.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 export type SpeechBubbleTailDirection = 'left' | 'right' | 'top' | 'bottom';
 
 type SpeechBubbleProps = ComponentProps<'div'> & {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   tailDirection?: SpeechBubbleTailDirection;
   size?: 'sm' | 'md' | 'lg';
   variant?: 'default' | 'secondary';
@@ -19,7 +19,7 @@ type SpeechBubbleProps = ComponentProps<'div'> & {
  */
 export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
   const {
-    children,
+    children = '',
     tailDirection = 'left',
     className,
     size = 'md',

--- a/src/shared/ui/SpeechBubble/SpeechBubble.tsx
+++ b/src/shared/ui/SpeechBubble/SpeechBubble.tsx
@@ -18,13 +18,7 @@ export interface SpeechBubbleProps {
  * 말풍선 컴포넌트
  * 다양한 방향의 꼬리와 크기, 스타일 변형을 지원합니다.
  */
-export const SpeechBubble: React.FC<SpeechBubbleProps> = ({
-  children,
-  tailDirection = 'left',
-  className,
-  size = 'md',
-  variant = 'default',
-}) => {
+export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
   // 크기별 스타일
   const sizeClasses = {
     sm: 'p-3 text-xs max-w-[200px]',
@@ -40,7 +34,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = ({
 
   // 꼬리 스타일 (variant에 따라 색상 변경)
   const getTailColors = () => {
-    switch (variant) {
+    switch (props.variant) {
       case 'secondary':
         return { borderColor: '#e5e7eb', fillColor: '#f3f4f6' }; // gray-200, gray-100
       default:
@@ -52,9 +46,9 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = ({
 
   // 꼬리 렌더링 함수
   const renderTail = () => {
-    const tailSize = size === 'sm' ? 10 : size === 'lg' ? 14 : 12;
+    const tailSize = props.size === 'sm' ? 10 : props.size === 'lg' ? 14 : 12;
 
-    switch (tailDirection) {
+    switch (props.tailDirection) {
       case 'left':
         return (
           <div className="absolute top-1/2 left-0 -translate-y-1/2 -translate-x-full">
@@ -160,12 +154,12 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = ({
     <div
       className={cn(
         'relative rounded-2xl shadow-lg border-2 font-medium leading-relaxed',
-        sizeClasses[size],
-        variantClasses[variant],
-        className,
+        sizeClasses[props.size || 'md'],
+        variantClasses[props.variant || 'default'],
+        props.className,
       )}
     >
-      <div className="whitespace-pre-line">{children}</div>
+      <div className="whitespace-pre-line">{props.children}</div>
       {renderTail()}
     </div>
   );

--- a/src/shared/ui/SpeechBubble/SpeechBubble.tsx
+++ b/src/shared/ui/SpeechBubble/SpeechBubble.tsx
@@ -29,7 +29,7 @@ const tailSizeMap = {
   lg: 14,
 } as const;
 
-type SpeechBubbleProps = ComponentProps<'div'> & {
+export type SpeechBubbleProps = ComponentProps<'div'> & {
   children?: React.ReactNode;
   tailDirection?: SpeechBubbleTailDirection;
   size?: 'sm' | 'md' | 'lg';

--- a/src/shared/ui/SpeechBubble/SpeechBubble.tsx
+++ b/src/shared/ui/SpeechBubble/SpeechBubble.tsx
@@ -19,6 +19,15 @@ export interface SpeechBubbleProps {
  * 다양한 방향의 꼬리와 크기, 스타일 변형을 지원합니다.
  */
 export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
+  const {
+    children,
+    tailDirection = 'left',
+    className,
+    size = 'md',
+    variant = 'default',
+    ...rest
+  } = props;
+
   // 크기별 스타일
   const sizeClasses = {
     sm: 'p-3 text-xs max-w-[200px]',
@@ -34,7 +43,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
 
   // 꼬리 스타일 (variant에 따라 색상 변경)
   const getTailColors = () => {
-    switch (props.variant) {
+    switch (variant) {
       case 'secondary':
         return { borderColor: '#e5e7eb', fillColor: '#f3f4f6' }; // gray-200, gray-100
       default:
@@ -46,15 +55,15 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
 
   // 꼬리 렌더링 함수
   const renderTail = () => {
-    const tailSize = props.size === 'sm' ? 10 : props.size === 'lg' ? 14 : 12;
+    const tailSize = size === 'sm' ? 10 : size === 'lg' ? 14 : 12;
 
-    switch (props.tailDirection) {
+    switch (tailDirection) {
       case 'left':
         return (
           <div className="absolute top-1/2 left-0 -translate-y-1/2 -translate-x-full">
             {/* 외부 테두리 */}
             <div
-              className="w-0 h-0"
+              className="size-0"
               style={{
                 borderTop: `${tailSize}px solid transparent`,
                 borderBottom: `${tailSize}px solid transparent`,
@@ -63,7 +72,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
             />
             {/* 내부 채우기 */}
             <div
-              className="absolute top-0 left-[4px] w-0 h-0"
+              className="absolute top-0 left-[4px] size-0"
               style={{
                 borderTop: `${tailSize}px solid transparent`,
                 borderBottom: `${tailSize}px solid transparent`,
@@ -78,7 +87,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
           <div className="absolute top-1/2 right-0 -translate-y-1/2 translate-x-full">
             {/* 외부 테두리 */}
             <div
-              className="w-0 h-0"
+              className="size-0"
               style={{
                 borderTop: `${tailSize}px solid transparent`,
                 borderBottom: `${tailSize}px solid transparent`,
@@ -87,7 +96,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
             />
             {/* 내부 채우기 */}
             <div
-              className="absolute top-0 right-[4px] w-0 h-0"
+              className="absolute top-0 right-[4px] size-0"
               style={{
                 borderTop: `${tailSize}px solid transparent`,
                 borderBottom: `${tailSize}px solid transparent`,
@@ -102,7 +111,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
           <div className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-full">
             {/* 외부 테두리 */}
             <div
-              className="w-0 h-0"
+              className="size-0"
               style={{
                 borderLeft: `${tailSize}px solid transparent`,
                 borderRight: `${tailSize}px solid transparent`,
@@ -111,7 +120,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
             />
             {/* 내부 채우기 */}
             <div
-              className="absolute top-[2px] left-0 w-0 h-0"
+              className="absolute top-[2px] left-0 size-0"
               style={{
                 borderLeft: `${tailSize}px solid transparent`,
                 borderRight: `${tailSize}px solid transparent`,
@@ -126,7 +135,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
           <div className="absolute left-1/2 bottom-0 -translate-x-1/2 translate-y-full">
             {/* 외부 테두리 */}
             <div
-              className="w-0 h-0"
+              className="size-0"
               style={{
                 borderLeft: `${tailSize}px solid transparent`,
                 borderRight: `${tailSize}px solid transparent`,
@@ -135,7 +144,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
             />
             {/* 내부 채우기 */}
             <div
-              className="absolute bottom-[2px] left-0 w-0 h-0"
+              className="absolute bottom-[2px] left-0 size-0"
               style={{
                 borderLeft: `${tailSize}px solid transparent`,
                 borderRight: `${tailSize}px solid transparent`,
@@ -154,12 +163,13 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
     <div
       className={cn(
         'relative rounded-2xl shadow-lg border-2 font-medium leading-relaxed',
-        sizeClasses[props.size || 'md'],
-        variantClasses[props.variant || 'default'],
-        props.className,
+        sizeClasses[size],
+        variantClasses[variant],
+        className,
       )}
+      {...rest}
     >
-      <div className="whitespace-pre-line">{props.children}</div>
+      <div className="whitespace-pre-line">{children}</div>
       {renderTail()}
     </div>
   );

--- a/src/shared/ui/SpeechBubble/SpeechBubble.tsx
+++ b/src/shared/ui/SpeechBubble/SpeechBubble.tsx
@@ -4,30 +4,14 @@ import React, { ComponentProps } from 'react';
 
 import { cn } from '@/lib/utils';
 
+import {
+  sizeVariants,
+  variantVariants,
+  tailColorVariants,
+  tailSizeVariants,
+} from './SpeechBubbleVariants';
+
 export type SpeechBubbleTailDirection = 'left' | 'right' | 'top' | 'bottom';
-
-// 크기별 스타일일
-const sizeClasses = {
-  sm: 'p-3 text-xs max-w-[200px]',
-  md: 'p-4 text-sm max-w-[280px]',
-  lg: 'p-5 text-base max-w-[320px]',
-} as const;
-
-const variantClasses = {
-  default: 'bg-white text-black border-gray-100',
-  secondary: 'bg-gray-100 text-gray-900 border-gray-200',
-} as const;
-
-const tailColorMap = {
-  default: { borderColor: '#f3f4f6', fillColor: '#ffffff' },
-  secondary: { borderColor: '#e5e7eb', fillColor: '#f3f4f6' },
-} as const;
-
-const tailSizeMap = {
-  sm: 10,
-  md: 12,
-  lg: 14,
-} as const;
 
 export type SpeechBubbleProps = ComponentProps<'div'> & {
   children?: React.ReactNode;
@@ -50,8 +34,8 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
     ...rest
   } = props;
 
-  const tailColors = tailColorMap[variant];
-  const tailSize = tailSizeMap[size];
+  const tailColors = tailColorVariants[variant];
+  const tailSize = tailSizeVariants[size];
 
   // 꼬리 렌더링 함수
   const renderTail = () => {
@@ -159,12 +143,7 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
 
   return (
     <div
-      className={cn(
-        'relative rounded-2xl shadow-lg border-2 font-medium leading-relaxed',
-        sizeClasses[size],
-        variantClasses[variant],
-        className,
-      )}
+      className={cn('relative', sizeVariants({ size }), variantVariants({ variant }), className)}
       {...rest}
     >
       <div className="whitespace-pre-line">{children}</div>

--- a/src/shared/ui/SpeechBubble/SpeechBubble.tsx
+++ b/src/shared/ui/SpeechBubble/SpeechBubble.tsx
@@ -6,6 +6,29 @@ import { cn } from '@/lib/utils';
 
 export type SpeechBubbleTailDirection = 'left' | 'right' | 'top' | 'bottom';
 
+// 크기별 스타일일
+const sizeClasses = {
+  sm: 'p-3 text-xs max-w-[200px]',
+  md: 'p-4 text-sm max-w-[280px]',
+  lg: 'p-5 text-base max-w-[320px]',
+} as const;
+
+const variantClasses = {
+  default: 'bg-white text-black border-gray-100',
+  secondary: 'bg-gray-100 text-gray-900 border-gray-200',
+} as const;
+
+const tailColorMap = {
+  default: { borderColor: '#f3f4f6', fillColor: '#ffffff' },
+  secondary: { borderColor: '#e5e7eb', fillColor: '#f3f4f6' },
+} as const;
+
+const tailSizeMap = {
+  sm: 10,
+  md: 12,
+  lg: 14,
+} as const;
+
 type SpeechBubbleProps = ComponentProps<'div'> & {
   children?: React.ReactNode;
   tailDirection?: SpeechBubbleTailDirection;
@@ -27,35 +50,11 @@ export const SpeechBubble: React.FC<SpeechBubbleProps> = (props) => {
     ...rest
   } = props;
 
-  // 크기별 스타일
-  const sizeClasses = {
-    sm: 'p-3 text-xs max-w-[200px]',
-    md: 'p-4 text-sm max-w-[280px]',
-    lg: 'p-5 text-base max-w-[320px]',
-  };
-
-  // 변형별 스타일
-  const variantClasses = {
-    default: 'bg-white text-black border-gray-100',
-    secondary: 'bg-gray-100 text-gray-900 border-gray-200',
-  };
-
-  // 꼬리 스타일 (variant에 따라 색상 변경)
-  const getTailColors = () => {
-    switch (variant) {
-      case 'secondary':
-        return { borderColor: '#e5e7eb', fillColor: '#f3f4f6' }; // gray-200, gray-100
-      default:
-        return { borderColor: '#f3f4f6', fillColor: '#ffffff' }; // gray-100, white
-    }
-  };
-
-  const tailColors = getTailColors();
+  const tailColors = tailColorMap[variant];
+  const tailSize = tailSizeMap[size];
 
   // 꼬리 렌더링 함수
   const renderTail = () => {
-    const tailSize = size === 'sm' ? 10 : size === 'lg' ? 14 : 12;
-
     switch (tailDirection) {
       case 'left':
         return (

--- a/src/shared/ui/SpeechBubble/SpeechBubble.tsx
+++ b/src/shared/ui/SpeechBubble/SpeechBubble.tsx
@@ -1,18 +1,17 @@
 'use client';
 
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
 import { cn } from '@/lib/utils';
 
 export type SpeechBubbleTailDirection = 'left' | 'right' | 'top' | 'bottom';
 
-export interface SpeechBubbleProps {
+type SpeechBubbleProps = ComponentProps<'div'> & {
   children: React.ReactNode;
   tailDirection?: SpeechBubbleTailDirection;
-  className?: string;
   size?: 'sm' | 'md' | 'lg';
   variant?: 'default' | 'secondary';
-}
+};
 
 /**
  * 말풍선 컴포넌트

--- a/src/shared/ui/SpeechBubble/SpeechBubbleVariants.ts
+++ b/src/shared/ui/SpeechBubble/SpeechBubbleVariants.ts
@@ -1,0 +1,40 @@
+import { cva } from 'class-variance-authority';
+
+export const sizeVariants = cva('font-medium leading-relaxed', {
+  variants: {
+    size: {
+      sm: 'p-3 text-xs max-w-[200px]',
+      md: 'p-4 text-sm max-w-[280px]',
+      lg: 'p-5 text-base max-w-[320px]',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+// 스타일 variants
+export const variantVariants = cva('rounded-2xl shadow-lg border-2', {
+  variants: {
+    variant: {
+      default: 'bg-white text-black border-gray-100',
+      secondary: 'bg-gray-100 text-gray-900 border-gray-200',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+// 꼬리 색상 variants
+export const tailColorVariants = {
+  default: { borderColor: '#f3f4f6', fillColor: '#ffffff' },
+  secondary: { borderColor: '#e5e7eb', fillColor: '#f3f4f6' },
+} as const;
+
+// 꼬리 크기 variants
+export const tailSizeVariants = {
+  sm: 10,
+  md: 12,
+  lg: 14,
+} as const;


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #416 

### 🔎 작업 내용

- [x] SpeechBubble 컴포넌트의 props 구조 분해를 전체 props로 변경
- [x] 기본값 설정 및 props 구조 분해 최적화로 안전성 강화
- [x] ComponentProps<'div'> 적용으로 HTML div 요소의 모든 속성 자동 지원
- [x] 필수 props를 선택적으로 변경하여 사용 유연성 향상
- [x] 조건부 스타일링을 객체로 분리하여 가독성 및 유지보수성 향상

### 📸 스크린샷 (선택)

### 📢 전달사항
1. 코드 간결성 대폭 향상: 개별 props 구조 분해를 전체 props 객체로 변경하여 중복 코드 제거
2. 유지보수성 개선: props가 추가될 때마다 코드를 두 군데서 수정할 필요 없음
3. 확장성 강화: ComponentProps<'div'> 적용으로 HTML div 요소의 모든 속성 자동 지원
4. 타입 안전성 보장: TypeScript와 함께 사용할 때 모든 유효한 props를 컴파일 타임에 체크
5. 개발자 경험 향상: IDE 자동완성 지원 및 실수 가능성 최소화

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * SpeechBubble 컴포넌트의 스타일 관련 상수와 매핑을 컴포넌트 외부로 분리하여 유지보수성과 확장성을 개선했습니다.
  * 추가적인 div 속성 전달이 가능하도록 props 구조를 개선했습니다.
  * tail 렌더링 로직 및 클래스 네이밍을 간소화했습니다.
  * 시각적 동작이나 기능에는 변화가 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->