### PR TITLE
UF-370 AppLayoutProvider 메인 영역을 네비게이션이 잡아먹는 버그 수정

### DIFF
--- a/src/app/blackhole/layout.tsx
+++ b/src/app/blackhole/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function BlackholeLayout({ children }: { children: React.ReactNode }) {
-  return <div className="min-h-screen w-full">{children}</div>;
+  return <div>{children}</div>;
 }

--- a/src/app/blackhole/page.tsx
+++ b/src/app/blackhole/page.tsx
@@ -12,7 +12,7 @@ function BlackholePageInner() {
   const mode = searchParams.get('mode') || 'self';
 
   return (
-    <div className="flex flex-col min-h-full w-full">
+    <div className="flex flex-col items-center justify-center">
       <Title title="홈" iconVariant="back" />
       <div className="flex flex-col items-center justify-center flex-1 w-full px-4">
         <div className="flex flex-col items-center">

--- a/src/app/charge/layout.tsx
+++ b/src/app/charge/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function ChargeLayout({ children }: { children: React.ReactNode }) {
-  return <div className="min-h-full w-full">{children}</div>;
+  return <div className="h-full w-full">{children}</div>;
 }

--- a/src/app/charge/page.tsx
+++ b/src/app/charge/page.tsx
@@ -9,7 +9,7 @@ export default function ZetChargePage() {
   const { handleChargePackage, isProcessing } = useZetCharge();
 
   return (
-    <div className="min-h-full flex flex-col">
+    <div className="h-full flex flex-col">
       <div className="px-4 pt-4">
         <div className="flex items-center justify-between mb-2">
           <Title title="ZET 코인 충전소" iconVariant="back" />

--- a/src/app/exchange/bulk/layout.tsx
+++ b/src/app/exchange/bulk/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function BulkPurchaseLayout({ children }: { children: React.ReactNode }) {
-  return <div className="min-h-full w-full">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/exchange/bulk/page.tsx
+++ b/src/app/exchange/bulk/page.tsx
@@ -30,7 +30,7 @@ export default function BulkPurchasePage() {
   };
 
   return (
-    <div className="flex flex-col min-h-full w-full justify-center px-4 pb-12">
+    <div className="pb-10">
       <Title title="일괄구매" iconVariant="back" />
       <div className="relative rounded-[20px] space-y-6 pb-12">
         {/* 거래 제안서 헤더 */}

--- a/src/app/exchange/bulk/result/index.tsx
+++ b/src/app/exchange/bulk/result/index.tsx
@@ -114,7 +114,7 @@ export default function BulkResultPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex items-center justify-center min-h-full">
+        <div className="flex items-center justify-center h-full">
           <div className="text-white">로딩 중...</div>
         </div>
       }

--- a/src/app/exchange/bulk/result/layout.tsx
+++ b/src/app/exchange/bulk/result/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function BulkPurchaseLayout({ children }: { children: React.ReactNode }) {
-  return <div className="min-h-full w-full">{children}</div>;
+  return <div className="h-full w-full">{children}</div>;
 }

--- a/src/app/exchange/layout.tsx
+++ b/src/app/exchange/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function OnboardingLayout({ children }: { children: React.ReactNode }) {
-  return <div className="min-h-full w-full">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/exchange/notification/page.tsx
+++ b/src/app/exchange/notification/page.tsx
@@ -90,7 +90,7 @@ const FilterNotificationPage = () => {
   };
 
   return (
-    <div className="flex flex-col justify-start items-center w-full min-h-full">
+    <div>
       <Title title="알림 조건 설정" iconVariant="back" />
       <div className="overflow-y-auto flex flex-col gap-4 h-full mb-4 hide-scrollbar w-full px-4">
         {/* 통신사 선택 */}

--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -88,7 +88,7 @@ export default function ExchangePage() {
   };
 
   return (
-    <div className="flex flex-col min-h-full w-full pb-6">
+    <div className="pb-6">
       <div className="flex-1">
         {/* 헤더 */}
         <div className="flex items-center justify-between">

--- a/src/app/exchange/purchase/[id]/page.tsx
+++ b/src/app/exchange/purchase/[id]/page.tsx
@@ -57,7 +57,7 @@ export default function PurchasePage() {
   }
 
   return (
-    <div className="flex flex-col items-center min-h-full px-4">
+    <div>
       <Title title="데이터 구매하기" iconVariant="back" />
 
       {/* 안내 텍스트 */}

--- a/src/app/exchange/purchase/[id]/step1/page.tsx
+++ b/src/app/exchange/purchase/[id]/step1/page.tsx
@@ -104,7 +104,7 @@ export default function Step1Page() {
 
   if (error || !productData) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-full px-4">
+      <div className="flex flex-col items-center justify-center h-full px-4">
         <Title title="데이터 구매하기" iconVariant="back" />
         <p className="text-red-400 text-center mb-4">{error}</p>
         <Button variant="secondary" onClick={() => router.back()} className="px-6 py-2">
@@ -117,7 +117,7 @@ export default function Step1Page() {
   const hasEnoughZet = userZet >= productData.totalPrice;
 
   return (
-    <div className="flex flex-col min-h-full px-4">
+    <div className="flex flex-col h-full px-4">
       <Title title="데이터 구매하기" iconVariant="back" />
 
       <div className="flex flex-col items-center justify-center flex-1">

--- a/src/app/exchange/purchase/[id]/step2/page.tsx
+++ b/src/app/exchange/purchase/[id]/step2/page.tsx
@@ -7,7 +7,7 @@ import { exchangeAPI, purchaseHistory } from '@/api';
 import type { ExchangePost } from '@/api/types/exchange';
 import { IMAGE_PATHS } from '@/constants/images';
 import { useUserRole } from '@/features/signup/hooks/useUserRole';
-import { Button, Title } from '@/shared';
+import { Button, Loading, Title } from '@/shared';
 import { analytics } from '@/utils/analytics';
 
 export default function Step2Page() {
@@ -84,19 +84,12 @@ export default function Step2Page() {
   };
 
   if (isLoading) {
-    return (
-      <div className="flex flex-col items-center h-full px-4">
-        <Title title="데이터 구매하기" iconVariant="back" />
-        <div className="flex items-center justify-center flex-1">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
-        </div>
-      </div>
-    );
+    return <Loading />;
   }
 
   if (!productData) {
     return (
-      <div className="flex flex-col justify-center items-center w-full min-h-full px-4">
+      <>
         <Title title="데이터 구매하기" iconVariant="back" />
         <div className="flex flex-col flex-1">
           <p className="text-red-400 text-center mb-4">상품 정보를 불러올 수 없습니다.</p>
@@ -104,12 +97,12 @@ export default function Step2Page() {
             돌아가기
           </Button>
         </div>
-      </div>
+      </>
     );
   }
 
   return (
-    <div className="flex flex-col items-center h-full px-4">
+    <>
       <Title title="데이터 구매하기" iconVariant="back" />
 
       {/* 데이터 큐브 이미지 */}
@@ -203,6 +196,6 @@ export default function Step2Page() {
       >
         다음
       </Button>
-    </div>
+    </>
   );
 }

--- a/src/app/exchange/purchase/[id]/step3/page.tsx
+++ b/src/app/exchange/purchase/[id]/step3/page.tsx
@@ -102,19 +102,19 @@ export default function Step3Page() {
   // 로딩 중
   if (isLoading) {
     return (
-      <div className="flex flex-col min-h-full px-4">
+      <>
         <Title title="데이터 구매하기" iconVariant="back" />
         <div className="flex items-center justify-center flex-1">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
         </div>
-      </div>
+      </>
     );
   }
 
   // 초기 에러
   if (error || !productData) {
     return (
-      <div className="flex flex-col min-h-full items-center justify-center px-4">
+      <div className="flex flex-col h-full items-center justify-center px-4">
         <Title title="데이터 구매하기" iconVariant="back" />
         <p className="text-red-400 text-center mb-4">{error}</p>
         <Button variant="secondary" onClick={() => router.back()}>
@@ -127,7 +127,7 @@ export default function Step3Page() {
   // 구매 완료 화면
   if (state.status === 'success') {
     return (
-      <div className="flex flex-col min-h-full">
+      <>
         <Title title="데이터 구매하기" iconVariant="back" />
 
         <div className="flex flex-col items-center justify-center flex-1 text-white text-center">
@@ -167,7 +167,7 @@ export default function Step3Page() {
             확인
           </Button>
         </div>
-      </div>
+      </>
     );
   }
 
@@ -176,7 +176,7 @@ export default function Step3Page() {
 
   return (
     <>
-      <div className="flex flex-col min-h-full w-full px-4">
+      <div className="flex flex-col h-full w-full px-4">
         <Title title="데이터 구매하기" iconVariant="back" />
 
         <div className="flex flex-col items-center justify-center flex-1">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -24,7 +24,7 @@ const LoginPage = () => {
   };
 
   return (
-    <div className="flex flex-col justify-center items-center w-full min-h-screen pb-[20px]">
+    <div className="flex flex-col justify-center items-center w-full h-full pb-[20px]">
       <div className="flex flex-[0.9] flex-col justify-center items-center text-center gap-5 w-full h-full pb-16">
         <div className="flex flex-col justify-center items-center w-[300px] h-[80px] gap-8">
           <Image src={ICON_PATHS['UFO_LOGO']} width={134.5} height={136} alt="ufo" />

--- a/src/app/login/success/page.tsx
+++ b/src/app/login/success/page.tsx
@@ -109,7 +109,7 @@ const SuccessPage = () => {
   }, [router, setPhoneNumber, setToast]);
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-full">
+    <div className="flex flex-col items-center justify-center h-full">
       <Loading />
     </div>
   );

--- a/src/app/mypage/achievement/page.tsx
+++ b/src/app/mypage/achievement/page.tsx
@@ -78,7 +78,7 @@ export default function AchievementPage() {
   if (error) return <>{error}</>;
 
   return (
-    <div className="relative gap-6">
+    <div className="relative flex gap-6">
       <Title iconVariant="back" className="w-full body-20-bold pb-2" title="업적 도감" />
       <p className="w-full text-center caption-12-medium">
         작지만 즐거운 업적을 모두 달성하고

--- a/src/app/mypage/achievement/page.tsx
+++ b/src/app/mypage/achievement/page.tsx
@@ -75,11 +75,10 @@ export default function AchievementPage() {
   }, []);
 
   if (isLoading) return <Loading />;
-  if (error)
-    return <div className="w-full min-h-full flex justify-center items-center">{error}</div>;
+  if (error) return <>{error}</>;
 
   return (
-    <div className="relative w-full min-h-full items-center flex flex-col gap-6">
+    <div className="relative gap-6">
       <Title iconVariant="back" className="w-full body-20-bold pb-2" title="업적 도감" />
       <p className="w-full text-center caption-12-medium">
         작지만 즐거운 업적을 모두 달성하고

--- a/src/app/mypage/edit-profile/page.tsx
+++ b/src/app/mypage/edit-profile/page.tsx
@@ -46,7 +46,7 @@ export default function EditProfilePage() {
   };
 
   return (
-    <div className="flex flex-col min-h-full w-full">
+    <div>
       <Title title="프로필 수정" iconVariant="back" />
 
       <div className="mt-6 flex flex-col gap-8">

--- a/src/app/mypage/follow/layout.tsx
+++ b/src/app/mypage/follow/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <div className="w-full min-h-full">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/mypage/follow/page.tsx
+++ b/src/app/mypage/follow/page.tsx
@@ -59,7 +59,7 @@ export default function Page() {
   };
 
   return (
-    <div className="min-h-full w-full text-white">
+    <div className="h-full w-full text-white">
       <Title title="팔로우 목록" iconVariant="back" />
 
       <div className="mx-4 mb-6">

--- a/src/app/mypage/notification/page.tsx
+++ b/src/app/mypage/notification/page.tsx
@@ -57,7 +57,7 @@ const MypageNotificationPage = () => {
   };
 
   return (
-    <div className="body-16-semibold w-full h-full flex flex-col items-center pt-4 gap-4 text-white">
+    <div className="body-16-semibold flex flex-col items-center pt-4 pb-6 gap-4 text-white">
       <Title title="알림 설정하기" iconVariant="back" />
 
       <div className="w-full flex flex-col gap-6">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -10,7 +10,7 @@ import { LogoutModal } from '@/features/mypage/components';
 import MenuSection from '@/features/mypage/components/MenuSection';
 import SignalCard from '@/features/mypage/components/SignalCard';
 import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
-import { Button, Icon, IconType, Loading } from '@/shared';
+import { Button, Icon, IconType, Loading, Title } from '@/shared';
 import { useToastStore } from '@/stores/useToastStore';
 import { Honorific } from '@/types/Achievement';
 
@@ -104,7 +104,7 @@ export default function MyPage() {
     }
 
     return (
-      <div className="w-full min-h-full flex flex-1 items-center justify-center">
+      <>
         <div className="text-center">
           <div className="text-red-400 mb-4">
             <Icon name="AlertCircle" size={48} className="mx-auto mb-2" />
@@ -120,14 +120,14 @@ export default function MyPage() {
             다시 시도
           </Button>
         </div>
-      </div>
+      </>
     );
   }
 
   // 데이터가 없는 경우
   if (!mypageInfo) {
     return (
-      <div className="w-full min-h-full flex flex-1 items-center justify-center">
+      <>
         <div className="text-center text-white">
           <p>프로필 정보가 없습니다</p>
           <button
@@ -138,12 +138,13 @@ export default function MyPage() {
             새로고침
           </button>
         </div>
-      </div>
+      </>
     );
   }
 
   return (
-    <div className="w-full text-white py-6">
+    <div>
+      <Title title="마이페이지" />
       {/* Signal Card */}
       <SignalCard
         userId={mypageInfo.nickname || '사용자'}

--- a/src/app/mypage/privacy/layout.tsx
+++ b/src/app/mypage/privacy/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <div className="w-full min-h-full">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/mypage/service/layout.tsx
+++ b/src/app/mypage/service/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <div className="w-full min-h-full">{children}</div>;
+  return <div className="">{children}</div>;
 }

--- a/src/app/mypage/trade/page.tsx
+++ b/src/app/mypage/trade/page.tsx
@@ -140,13 +140,8 @@ const MyTradeHistoryPage = () => {
       ));
 
   return (
-    <div className="flex flex-col justify-start w-full min-h-full">
-      <Tabs
-        defaultValue="sell"
-        value={tab}
-        onValueChange={handleTabChange}
-        className="w-full h-full"
-      >
+    <div>
+      <Tabs defaultValue="sell" value={tab} onValueChange={handleTabChange}>
         <TabsList className="my-4 w-auto px-10 gap-10">
           <TabsTrigger value="sell" variant="darkTab" size="full">
             판매 내역

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -40,7 +40,7 @@ export default function OnboardingPage() {
   };
 
   return (
-    <div className="min-h-full flex flex-col justify-center items-center px-4 py-6">
+    <div className="h-full flex flex-col justify-center items-center px-4 py-6">
       <div className="w-full max-w-[560px]">
         <div
           className={`transition-all duration-500 ease-in-out flex flex-col items-center ${

--- a/src/app/payment/account/page.tsx
+++ b/src/app/payment/account/page.tsx
@@ -65,7 +65,7 @@ export default function AccountConnectPage() {
   const isButtonActive = account.trim().length > 0 && selectedBank !== null;
 
   return (
-    <div className="relative min-h-full flex flex-col bg-transparent pb-24">
+    <div className="relative h-full flex flex-col bg-transparent pb-24">
       <button
         type="button"
         onClick={() => router.back()}

--- a/src/app/payment/account/success/layout.tsx
+++ b/src/app/payment/account/success/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function PaymentLayout({ children }: { children: React.ReactNode }) {
-  return <div className="w-full min-h-full">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/payment/fail/layout.tsx
+++ b/src/app/payment/fail/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function PaymentLayout({ children }: { children: React.ReactNode }) {
-  return <div className="w-full min-h-full">{children}</div>;
+  return <div>{children}</div>;
 }

--- a/src/app/payment/fail/page.tsx
+++ b/src/app/payment/fail/page.tsx
@@ -28,7 +28,7 @@ function PaymentFailContent() {
   }, [searchParams]);
 
   return (
-    <div className="flex flex-col min-h-full w-full">
+    <div className="flex flex-col h-full w-full">
       <Title title="" iconVariant="close" />
 
       {/* 메인 컨텐츠 영역 */}

--- a/src/app/payment/success/layout.tsx
+++ b/src/app/payment/success/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function PaymentLayout({ children }: { children: React.ReactNode }) {
-  return <div className="w-full min-h-full">{children}</div>;
+  return <div>{children}</div>;
 }

--- a/src/app/profile/[userId]/datalist/page.tsx
+++ b/src/app/profile/[userId]/datalist/page.tsx
@@ -10,21 +10,11 @@ export default function ProfileDataListPage() {
   const userId = Number(params.userId);
 
   if (isNaN(userId) || userId <= 0) {
-    return (
-      <div className="flex items-center justify-center min-h-full">
-        <div className="text-white">잘못된 사용자 ID입니다.</div>
-      </div>
-    );
+    return <div className="text-white">잘못된 사용자 ID입니다.</div>;
   }
 
   return (
-    <Suspense
-      fallback={
-        <div className="flex items-center justify-center min-h-full">
-          <div className="text-white">판매 데이터를 불러오는 중...</div>
-        </div>
-      }
-    >
+    <Suspense fallback={<div className="text-white">판매 데이터를 불러오는 중...</div>}>
       <DataListView userId={userId} />
     </Suspense>
   );

--- a/src/app/profile/[userId]/layout.tsx
+++ b/src/app/profile/[userId]/layout.tsx
@@ -54,5 +54,5 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default function ProfileLayout({ children }: Props) {
-  return <div className="min-h-full w-full">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/profile/[userId]/loading.tsx
+++ b/src/app/profile/[userId]/loading.tsx
@@ -1,7 +1,0 @@
-export default function ProfileLoading() {
-  return (
-    <div className="flex items-center justify-center w-full min-h-full">
-      <div className="text-white">프로필을 불러오는 중...</div>
-    </div>
-  );
-}

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -10,21 +10,11 @@ export default function ProfilePage() {
   const userId = Number(params.userId);
 
   if (!userId || isNaN(userId)) {
-    return (
-      <div className="flex items-center justify-center min-h-full">
-        <div className="text-white">잘못된 사용자 ID입니다.</div>
-      </div>
-    );
+    return <div className="text-white">잘못된 사용자 ID입니다.</div>;
   }
 
   return (
-    <Suspense
-      fallback={
-        <div className="flex items-center justify-center min-h-full">
-          <div className="text-white">프로필을 불러오는 중...</div>
-        </div>
-      }
-    >
+    <Suspense fallback={<div className="text-white">프로필을 불러오는 중...</div>}>
       <ProfileView userId={userId} />
     </Suspense>
   );

--- a/src/app/sell/edit/[id]/layout.tsx
+++ b/src/app/sell/edit/[id]/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function EditLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-full w-full">
+    <div className="h-full w-full">
       <EditProvider>{children}</EditProvider>
     </div>
   );

--- a/src/app/sell/edit/[id]/page.tsx
+++ b/src/app/sell/edit/[id]/page.tsx
@@ -38,7 +38,7 @@ export default function SellEditPage() {
   // postData가 없으면 로딩 상태
   if (!postData) {
     return (
-      <div className="flex items-center justify-center min-h-full">
+      <div className="flex items-center justify-center h-full">
         <div className="text-white">게시글 정보를 불러오는 중...</div>
       </div>
     );
@@ -79,7 +79,7 @@ export default function SellEditPage() {
   };
 
   return (
-    <div className="flex flex-col min-h-full w-full justify-center">
+    <div className="flex flex-col h-full w-full justify-center">
       <Title title="데이터 판매 수정" iconVariant="back" />
       <div className="relative rounded-[20px] space-y-6 pb-16 xs:pb-32">
         {/* 거래명세서 타이틀 */}

--- a/src/app/sell/layout.tsx
+++ b/src/app/sell/layout.tsx
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function OnboardingLayout({ children }: { children: React.ReactNode }) {
-  return <div className="w-full min-h-full">{children}</div>;
+  return <div>{children}</div>;
 }

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -1,3 +1,4 @@
+// src/app/sell/page.tsx
 'use client';
 
 import Image from 'next/image';
@@ -31,13 +32,13 @@ export default function SellPage() {
   } = useSellData();
 
   const isFormValid = isValidTitle && isValidPrice && isValidCapacity;
-
   const isMobile = useViewportStore((state) => state.isMobile);
 
   return (
-    <div className="flex flex-col min-h-full w-full justify-center overflow-hidden">
+    <div className="relative w-full h-full flex flex-col">
       <Title title="데이터 판매 등록" />
-      <div className="relative rounded-[20px] space-y-6 pb-16 xs:pb-32 overflow-hidden">
+
+      <div className="flex-1 space-y-6 py-4">
         {/* 거래명세서 타이틀 */}
         <div className="flex items-center space-x-3">
           <Icon name="FilePenLine" color="white" />
@@ -105,7 +106,7 @@ export default function SellPage() {
         />
 
         {/* 등록 버튼 */}
-        <div className="w-full mx-auto pt-2 flex justify-end relative">
+        <div className="w-full pt-2 flex justify-end">
           <Button
             size={isMobile ? 'default' : 'lg'}
             onClick={handleSubmit}
@@ -116,22 +117,12 @@ export default function SellPage() {
             {isSubmitting ? '등록 중...' : '등록하기'}
           </Button>
         </div>
-
-        {/* 하단 캐릭터 */}
-        <Image
-          src={IMAGE_PATHS.AL_SELL}
-          alt="판매 우주인"
-          width={200}
-          height={200}
-          className="absolute bottom-12 xs:-bottom-28 left-0"
-          priority
-        />
       </div>
-      <style jsx>{`
-        body {
-          overscroll-behavior: none;
-        }
-      `}</style>
+
+      {/* 하단 캐릭터 - 절대 위치로 배치 */}
+      <div className="absolute bottom-0 left-0 pointer-events-none">
+        <Image src={IMAGE_PATHS.AL_SELL} alt="판매 우주인" width={200} height={200} priority />
+      </div>
     </div>
   );
 }

--- a/src/app/signal/page.tsx
+++ b/src/app/signal/page.tsx
@@ -12,7 +12,7 @@ export default function SignalPage() {
   const [activeTab, setActiveTab] = useState<TabType>('orbit');
 
   return (
-    <div className="flex flex-col min-h-full w-full">
+    <div className="flex flex-col h-full w-full">
       <Title title="전파 거리" />
 
       {/* Tabs UI */}

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -24,5 +24,5 @@ export default function SignupLayout({ children }: { children: React.ReactNode }
     }
   }, [userRole, isLoading, router]);
 
-  return <div className="flex flex-col w-full min-h-full">{children}</div>;
+  return <div className="flex flex-col w-full h-full pb-6">{children}</div>;
 }

--- a/src/features/bulk/components/BulkPurchaseContent.tsx
+++ b/src/features/bulk/components/BulkPurchaseContent.tsx
@@ -63,7 +63,7 @@ export function BulkPurchaseContent() {
   }
 
   return (
-    <div className="w-full min-h-full flex flex-col gap-6">
+    <div className="w-full h-full flex flex-col gap-6">
       <Title title="일괄구매 결과" />
       <section>
         <p className="body-16-bold mb-3">구매한 데이터 ({postCounts[0] || 0}건)</p>

--- a/src/features/bulk/components/BulkResultContent.tsx
+++ b/src/features/bulk/components/BulkResultContent.tsx
@@ -91,7 +91,7 @@ export function BulkResultContent({ initialData }: BulkResultContentProps) {
 
   if (error || !resultData) {
     return (
-      <div className="flex flex-col min-h-full">
+      <div className="flex flex-col h-full">
         <Title title="매칭된 데이터" iconVariant="back" />
         <div className="flex items-center justify-center text-white">
           검색 결과를 찾을 수 없습니다.
@@ -102,7 +102,7 @@ export function BulkResultContent({ initialData }: BulkResultContentProps) {
 
   // 정상 상태
   return (
-    <div className="flex flex-col min-h-full w-full">
+    <div className="flex flex-col h-full w-full">
       <Title title="매칭된 데이터" iconVariant="back" />
       <div className="px-4">
         <BulkResultDisplay

--- a/src/features/exchange/components/EditProvider.tsx
+++ b/src/features/exchange/components/EditProvider.tsx
@@ -117,7 +117,7 @@ export const EditProvider = ({ children }: EditProviderProps) => {
   // 로딩 중
   if (isUserLoading || isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-full">
+      <div className="flex items-center justify-center h-full">
         <div className="text-white">권한을 확인하는 중...</div>
       </div>
     );

--- a/src/features/exchange/components/FilterBox.tsx
+++ b/src/features/exchange/components/FilterBox.tsx
@@ -26,7 +26,7 @@ export const FilterBox = ({
       )}
     >
       <div
-        className="absolute inset-0 w-full min-h-full rounded-2xl"
+        className="absolute inset-0 w-full h-full rounded-2xl"
         style={{
           background: 'var(--bg-trade-card)',
           opacity: 0.65,

--- a/src/features/exchange/components/SellingItem.tsx
+++ b/src/features/exchange/components/SellingItem.tsx
@@ -63,22 +63,13 @@ export default function SellingItem({
           <div>
             {/* 판매자 프로필 이미지 */}
             <Avatar variant="selling" size="sm">
-              {sellerProfileUrl ? (
-                <Image
-                  src={sellerProfileUrl || IMAGE_PATHS.AVATAR}
-                  alt={`${sellerNickname} 프로필`}
-                  width={32}
-                  height={32}
-                  className="w-full h-full object-cover rounded-full"
-                />
-              ) : (
-                // 프로필 이미지가 없을 때 기본 아이콘 또는 이니셜
-                <div className="w-full h-full bg-gray-500 rounded-full flex items-center justify-center">
-                  <span className="text-white text-xs font-bold">
-                    {sellerNickname.charAt(0).toUpperCase()}
-                  </span>
-                </div>
-              )}
+              <Image
+                src={sellerProfileUrl || IMAGE_PATHS.AVATAR}
+                alt={`${sellerNickname} 프로필`}
+                width={32}
+                height={32}
+                className="w-full h-full object-cover rounded-full"
+              />
             </Avatar>
           </div>
           <div className="flex flex-col items-end mb-1">

--- a/src/features/profile/components/DataListView/index.tsx
+++ b/src/features/profile/components/DataListView/index.tsx
@@ -17,7 +17,7 @@ export function DataListView({ userId }: DataListViewProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-full">
+      <div className="flex items-center justify-center h-full">
         <div className="text-white">판매 데이터를 불러오는 중...</div>
       </div>
     );
@@ -25,7 +25,7 @@ export function DataListView({ userId }: DataListViewProps) {
 
   if (error || !profile) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-full gap-4">
+      <div className="flex flex-col items-center justify-center h-full gap-4">
         <div className="text-white">판매 데이터를 불러올 수 없습니다.</div>
         <button onClick={() => router.back()} className="text-cyan-400 underline">
           돌아가기
@@ -35,7 +35,7 @@ export function DataListView({ userId }: DataListViewProps) {
   }
 
   return (
-    <div className="flex flex-col min-h-full w-full pb-6">
+    <div className="flex flex-col w-full pb-6">
       <Title title="판매중인 데이터 목록" iconVariant="back" />
 
       <div className="px-4 space-y-4">

--- a/src/features/profile/components/ProfileView/index.tsx
+++ b/src/features/profile/components/ProfileView/index.tsx
@@ -19,7 +19,7 @@ export function ProfileView({ userId }: ProfileViewProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-full">
+      <div className="flex items-center justify-center h-full">
         <div className="text-white">프로필을 불러오는 중...</div>
       </div>
     );
@@ -27,7 +27,7 @@ export function ProfileView({ userId }: ProfileViewProps) {
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-full gap-4">
+      <div className="flex flex-col items-center justify-center h-full gap-4">
         <div className="text-white">프로필을 불러올 수 없습니다.</div>
         <div className="text-red-400 text-sm">{error.message}</div>
         <button onClick={() => router.back()} className="text-cyan-400 underline">
@@ -39,7 +39,7 @@ export function ProfileView({ userId }: ProfileViewProps) {
 
   if (!profile) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-full gap-4">
+      <div className="flex flex-col items-center justify-center h-full gap-4">
         <div className="text-white">프로필을 찾을 수 없습니다.</div>
         <button onClick={() => router.back()} className="text-cyan-400 underline">
           돌아가기
@@ -49,7 +49,7 @@ export function ProfileView({ userId }: ProfileViewProps) {
   }
 
   return (
-    <div className="flex flex-col min-h-full w-full pb-6">
+    <div className="flex flex-col w-full pb-6">
       <Title title="프로필 보기" iconVariant="back" />
 
       <div className="space-y-6 px-4">

--- a/src/features/profile/stories/ProfileView.stories.tsx
+++ b/src/features/profile/stories/ProfileView.stories.tsx
@@ -97,7 +97,7 @@ const MockProfileView = ({
   const profile = getMockProfileById(userId);
 
   return (
-    <div className="flex flex-col min-h-full w-full pb-6">
+    <div className="flex flex-col w-full pb-6">
       <div className="flex items-center p-4 border-b border-white/10">
         <button className="text-white mr-4">←</button>
         <h1 className="text-white text-lg font-bold">{profile.nickname}의 프로필</h1>

--- a/src/features/signal/components/LetterTabContent.tsx
+++ b/src/features/signal/components/LetterTabContent.tsx
@@ -3,7 +3,7 @@ import SignalProgressBar from './SignalProgressBar';
 
 export default function LetterTabContent() {
   return (
-    <div className="w-full min-h-full flex flex-col justify-center items-center space-y-4">
+    <div className="w-full h-full flex flex-col justify-center items-center space-y-4">
       <div className="z-30 scale-85">
         <SignalProgressBar />
       </div>

--- a/src/provider/AppLayoutProvider.tsx
+++ b/src/provider/AppLayoutProvider.tsx
@@ -1,12 +1,28 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import React from 'react';
+import React, { createContext, useContext } from 'react';
 
 import { IMAGE_PATHS } from '@/constants/images';
 import { ScrollToTopButton } from '@/features/common/components/ScrollToTopButton';
 import BottomNav from '@/shared/layout/BottomNav';
 import TopNav from '@/shared/layout/TopNav';
+
+interface AppLayoutContextValue {
+  isAdminPage: boolean;
+  hideNavigation: boolean;
+  isPasswordPage: boolean;
+}
+
+const AppLayoutContext = createContext<AppLayoutContextValue | undefined>(undefined);
+
+export const useAppLayout = () => {
+  const context = useContext(AppLayoutContext);
+  if (!context) {
+    throw new Error('useAppLayout must be used within AppLayoutProvider');
+  }
+  return context;
+};
 
 interface AppLayoutProviderProps {
   children: React.ReactNode;
@@ -25,6 +41,15 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
     pathname.startsWith('/onboarding') ||
     pathname.startsWith('/blackhole') ||
     pathname.startsWith('/signup/privacy');
+
+  // 홈페이지만 중앙 정렬, 나머지는 일반 플렉스 컬럼
+  const isHomePage = pathname === '/';
+
+  const contextValue: AppLayoutContextValue = {
+    isAdminPage: isAdminRoute,
+    hideNavigation: isNavigationHidden,
+    isPasswordPage,
+  };
 
   const backgroundImageUrl = (() => {
     if (
@@ -50,44 +75,56 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
           backgroundImage: `url(${backgroundImageUrl})`,
           backgroundRepeat: 'no-repeat',
           backgroundSize: 'cover',
+          backgroundPosition: 'center', // 배경 이미지 중앙 정렬
         }
       : {};
 
-  if (isAdminRoute) return <>{children}</>;
+  if (isAdminRoute) {
+    return (
+      <AppLayoutContext.Provider value={contextValue}>
+        <div className="min-h-screen w-full bg-gray-50">{children}</div>
+      </AppLayoutContext.Provider>
+    );
+  }
 
   return (
-    <div className="min-h-screen w-full flex justify-center">
-      <div
-        className={`
-          relative w-full h-full min-w-[375px] max-w-[620px] overflow-hidden
-          ${backgroundImageUrl ? 'nav-container-bg' : ''}
-        `}
-        style={containerStyle}
-      >
-        {!isNavigationHidden && <TopNav />}
-        <main
-          className="overflow-y-auto overflow-x-hidden hide-scrollbar relative z-10 sm:px-10.5 px-6 text-white flex flex-col justify-center items-center"
-          style={{
-            minHeight: '100dvh',
-            paddingTop: isNavigationHidden ? '0px' : `${NAV_HEIGHT}px`,
-            paddingBottom: isNavigationHidden ? '0px' : `${BOTTOM_NAV_HEIGHT}px`,
-            height: isNavigationHidden
-              ? '100dvh'
-              : `calc(100dvh - ${NAV_HEIGHT + BOTTOM_NAV_HEIGHT}px)`,
-            WebkitOverflowScrolling: 'touch',
-            overscrollBehavior: 'contain',
-          }}
+    <AppLayoutContext.Provider value={contextValue}>
+      <div className="min-h-screen w-full flex justify-center">
+        <div
+          className={`
+            relative w-full h-full min-w-[375px] max-w-[620px] overflow-hidden
+            ${backgroundImageUrl ? 'nav-container-bg' : ''}
+          `}
+          style={containerStyle}
         >
-          {children}
-        </main>
-        {!isNavigationHidden && <BottomNav />}
+          {!isNavigationHidden && <TopNav />}
+          <main
+            className={`
+              overflow-y-auto overflow-x-hidden hide-scrollbar relative z-10 sm:px-10.5 px-6 text-white
+              ${isHomePage ? 'flex flex-col justify-center items-center' : 'flex flex-col'}
+            `}
+            style={{
+              minHeight: '100dvh',
+              paddingTop: isNavigationHidden ? '0px' : `${NAV_HEIGHT}px`,
+              paddingBottom: isNavigationHidden ? '32px' : `${BOTTOM_NAV_HEIGHT}px`,
+              height: isNavigationHidden
+                ? '100dvh'
+                : `calc(100dvh - ${NAV_HEIGHT + BOTTOM_NAV_HEIGHT}px)`,
+              WebkitOverflowScrolling: 'touch',
+              overscrollBehavior: 'contain',
+            }}
+          >
+            {children}
+          </main>
+          {!isNavigationHidden && <BottomNav />}
 
-        {!isNavigationHidden && (
-          <div className="absolute bottom-24 right-4 z-50">
-            <ScrollToTopButton />
-          </div>
-        )}
+          {!isNavigationHidden && (
+            <div className="absolute bottom-24 right-4 z-50">
+              <ScrollToTopButton />
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </AppLayoutContext.Provider>
   );
 }

--- a/src/provider/AppLayoutProvider.tsx
+++ b/src/provider/AppLayoutProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 
 import { IMAGE_PATHS } from '@/constants/images';
 import { ScrollToTopButton } from '@/features/common/components/ScrollToTopButton';
@@ -45,11 +45,14 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
   // 홈페이지만 중앙 정렬, 나머지는 일반 플렉스 컬럼
   const isHomePage = pathname === '/';
 
-  const contextValue: AppLayoutContextValue = {
-    isAdminPage: isAdminRoute,
-    hideNavigation: isNavigationHidden,
-    isPasswordPage,
-  };
+  const contextValue: AppLayoutContextValue = useMemo(
+    () => ({
+      isAdminPage: isAdminRoute,
+      hideNavigation: isNavigationHidden,
+      isPasswordPage,
+    }),
+    [isAdminRoute, isNavigationHidden, isPasswordPage],
+  );
 
   const backgroundImageUrl = (() => {
     if (

--- a/src/provider/ToastProvider.tsx
+++ b/src/provider/ToastProvider.tsx
@@ -1,17 +1,22 @@
 'use client';
 
-import { TOAST_CONFIG } from '@/constants';
-import { Toaster } from '@/shared';
+import { Toaster } from 'sonner';
 
-interface ToastProviderProps {
-  children: React.ReactNode;
-}
-
-export function ToastProvider({ children }: ToastProviderProps) {
+export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <>
       {children}
-      <Toaster className={`fixed bottom-[${TOAST_CONFIG.BOTTOM_OFFSET}] z-[9999]`} />
+      <Toaster
+        position="bottom-center"
+        expand={true}
+        richColors={true}
+        closeButton={true}
+        duration={3000}
+        visibleToasts={1}
+        offset="120px"
+        containerAriaLabel="알림"
+        className="z-[9999]"
+      />
     </>
   );
 }

--- a/src/shared/layout/BottomNav/BottomNav.tsx
+++ b/src/shared/layout/BottomNav/BottomNav.tsx
@@ -37,51 +37,49 @@ const BottomNav: React.FC<BottomNavProps> = ({ onTabChange }) => {
   };
 
   return (
-    <footer className="fixed bottom-0 left-1/2 transform -translate-x-1/2 h-16 z-30 w-full min-w-[375px] max-w-[620px]">
-      <div className="w-full h-16 bg-primary-700 border-t border-white/10">
-        <nav className="flex items-center justify-around h-16 w-full">
-          {navItems.map((item) => {
-            const isActive = activeTab === item.id;
-            const isHome = item.id === 'home';
+    <footer className="bottom-nav-fixed">
+      <nav className="flex items-center justify-around h-16 w-full">
+        {navItems.map((item) => {
+          const isActive = activeTab === item.id;
+          const isHome = item.id === 'home';
 
-            return (
-              <div
-                key={item.id}
-                className={cn('flex justify-center items-end h-16', {
-                  'relative z-10 w-18 mt-0': isHome,
-                  'flex-1': !isHome,
-                })}
+          return (
+            <div
+              key={item.id}
+              className={cn('flex justify-center items-end h-16', {
+                'relative z-10 w-18 mt-0': isHome,
+                'flex-1': !isHome,
+              })}
+            >
+              <button
+                onClick={() => handleTabClick(item.id)}
+                className={cn(
+                  'flex flex-col items-center justify-center gap-1 transition-all duration-200 cursor-pointer',
+                  isHome
+                    ? 'w-full h-[72px] bg-primary-400 rounded-t-3xl'
+                    : 'w-full h-16 hover:bg-white/5 active:scale-95',
+                  isActive ? 'text-secondary-yellow' : 'text-white/70',
+                )}
+                aria-label={item.label}
               >
-                <button
-                  onClick={() => handleTabClick(item.id)}
+                <Icon
+                  name={item.icon}
+                  size={isHome ? 'lg' : 'md'}
+                  color={isActive ? 'rgb(var(--color-secondary-yellow))' : 'white'}
+                />
+                <span
                   className={cn(
-                    'flex flex-col items-center justify-center gap-1 transition-all duration-200 cursor-pointer',
-                    isHome
-                      ? 'w-full h-[72px] bg-primary-400 rounded-t-3xl'
-                      : 'w-full h-16 hover:bg-white/5 active:scale-95',
+                    'text-xs font-bold leading-none',
                     isActive ? 'text-secondary-yellow' : 'text-white/70',
                   )}
-                  aria-label={item.label}
                 >
-                  <Icon
-                    name={item.icon}
-                    size={isHome ? 'lg' : 'md'}
-                    color={isActive ? 'rgb(var(--color-secondary-yellow))' : 'white'}
-                  />
-                  <span
-                    className={cn(
-                      'text-xs font-bold leading-none',
-                      isActive ? 'text-secondary-yellow' : 'text-white/70',
-                    )}
-                  >
-                    {item.label}
-                  </span>
-                </button>
-              </div>
-            );
-          })}
-        </nav>
-      </div>
+                  {item.label}
+                </span>
+              </button>
+            </div>
+          );
+        })}
+      </nav>
     </footer>
   );
 };

--- a/src/shared/layout/TopNav/TopNav.tsx
+++ b/src/shared/layout/TopNav/TopNav.tsx
@@ -96,8 +96,8 @@ const TopNav: React.FC<TopNavProps> = ({ title = 'UFO-Fi', onNotificationClick }
   const formattedZet = formatZetAmount(zetAsset);
 
   return (
-    <header className="fixed top-0 left-1/2 transform -translate-x-1/2 h-14 z-30 w-full min-w-[375px] max-w-[620px] bg-primary-700 shadow-sm">
-      <div className="flex items-center justify-between h-full px-4 w-full">
+    <header className="top-nav-fixed">
+      <div className="flex items-center justify-between h-14 px-4 w-full">
         {/* 로고 및 타이틀 */}
         <div className="flex items-center gap-3">
           {ICON_PATHS?.UFO_LOGO ? (

--- a/src/shared/ui/Loading/Loading.tsx
+++ b/src/shared/ui/Loading/Loading.tsx
@@ -51,7 +51,7 @@ export function Loading({
 
       default:
         return (
-          <div className="text-center">
+          <div className="text-center h-full">
             <div className="relative mb-4">
               <Image
                 src={IMAGE_PATHS.AL_SUCCESS}

--- a/src/styles/components/navigation.css
+++ b/src/styles/components/navigation.css
@@ -1,0 +1,24 @@
+@layer utilities {
+  /* Top Navigation */
+  .top-nav-fixed {
+    @apply fixed top-0 left-1/2 transform -translate-x-1/2 h-14 z-50 w-full min-w-[375px] max-w-[620px] bg-primary-700 shadow-sm;
+  }
+
+  /* Bottom Navigation */
+  .bottom-nav-fixed {
+    @apply fixed bottom-0 left-1/2 transform -translate-x-1/2 h-16 z-50 w-full min-w-[375px] max-w-[620px] bg-primary-700 border-t border-white/10;
+  }
+
+  /* Safe area 대응 */
+  @supports (padding: max(0px)) {
+    .top-nav-fixed {
+      padding-top: max(0px, env(safe-area-inset-top));
+      height: calc(56px + max(0px, env(safe-area-inset-top)));
+    }
+
+    .bottom-nav-fixed {
+      padding-bottom: max(0px, env(safe-area-inset-bottom));
+      height: calc(64px + max(0px, env(safe-area-inset-bottom)));
+    }
+  }
+}

--- a/src/styles/components/toast.css
+++ b/src/styles/components/toast.css
@@ -1,0 +1,27 @@
+@layer components {
+  [data-sonner-toaster] {
+    @apply z-[9999];
+    /* Safe area 대응 */
+    padding-top: max(0px, env(safe-area-inset-top));
+  }
+
+  [data-sonner-toaster] [data-sonner-toast] {
+    @apply z-[9999] shadow-lg rounded-lg;
+
+    margin-top: max(8px, env(safe-area-inset-top));
+  }
+
+  /* 모바일 전용 */
+  @media (max-width: 768px) {
+    [data-sonner-toaster][data-position='top-center'] {
+      top: max(80px, calc(56px + env(safe-area-inset-top) + 24px)) !important;
+    }
+  }
+
+  /* iOS Safari */
+  @supports (-webkit-touch-callout: none) {
+    [data-sonner-toaster][data-position='top-center'] {
+      top: max(100px, calc(56px + env(safe-area-inset-top) + 44px)) !important;
+    }
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,6 +4,8 @@
 @import './components/background.css';
 @import './components/typography.css';
 @import './components/buttons.css';
+@import './components/navigation.css';
+@import './components/toast.css';
 @import './utils/layout.css';
 @import './utils/mobile.css';
 
@@ -242,8 +244,6 @@
   --color-border-zet: #1379c8;
 
   --color-password-bg: #070d24;
-  --width-mobile-min: 375px;
-  --width-mobile-max: 620px;
 
   --color-hr-border: #777777;
   --color-badge-border: #d9d9d9;


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #435 

### 🔎 작업 내용

- [x] AppLayoutProvider의 네비게이션 영역 문제는 전역 스타일로 해결
- [x] 토스트 안 보이는 에러 수정을 위해서도 전역 스타일 관리로 해결

### 📸 스크린샷 (선택)

### 📢 전달사항
min-h-full을 먹고 있다면 전부 지워야합니다..
제가 전부 지워뒀습니다! (홈 제외)

또 문제가 발생하면 해당 페이지별로 수정해야합니다..!

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **Style**
  * 전체적으로 레이아웃과 컨테이너의 CSS 클래스(min-h-full → h-full 등)를 수정하여 높이 및 정렬 스타일을 개선했습니다.
  * 불필요한 래퍼(div)와 중복된 스타일 클래스를 제거해 DOM 구조를 단순화했습니다.
  * 네비게이션 및 토스트 관련 컴포넌트에 새로운 고정 위치 스타일(.top-nav-fixed, .bottom-nav-fixed 등)과 안전 영역 대응 CSS를 적용했습니다.
  * 일부 페이지 및 컴포넌트의 레이아웃 구조와 하위 요소 위치를 조정했습니다.

* **New Features**
  * 레이아웃 관련 상태를 제공하는 컨텍스트(AppLayoutContext)와 커스텀 훅(useAppLayout)을 추가하여, 페이지별 레이아웃 정보를 쉽게 사용할 수 있게 했습니다.
  * 토스트 알림 UI를 외부 라이브러리(sonner)로 교체하고, 위치·색상 등 다양한 옵션을 적용했습니다.

* **Refactor**
  * 로딩, 에러, 비어있는 상태 등에서 JSX 구조를 간소화하고, 공통 컴포넌트(Loading 등)의 재사용성을 높였습니다.
  * 일부 컴포넌트에서 조건부 렌더링 및 프로필 이미지 처리 로직을 단순화했습니다.

* **Chores**
  * 글로벌 스타일에 navigation.css, toast.css를 추가하여 네비게이션과 토스트 UI의 일관된 스타일을 적용했습니다.
  * 중복된 CSS 변수 선언을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->