### PR TITLE
UF-365 ZetDisplay 리팩토링

### DIFF
--- a/src/features/common/components/ZetDisplay/ZetDisplay.tsx
+++ b/src/features/common/components/ZetDisplay/ZetDisplay.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
-interface ZetDisplayProps {
-  amount: number;
-  className?: string;
+type ZetDisplayProps = ComponentProps<'span'> & {
+  amount?: number;
   showUnit?: boolean;
   size?: 'sm' | 'md' | 'lg';
-}
+};
 
 export const formatZetAmount = (amount: number): string => {
   if (amount >= 99999) {
@@ -15,7 +14,7 @@ export const formatZetAmount = (amount: number): string => {
 };
 
 export const ZetDisplay: React.FC<ZetDisplayProps> = (props) => {
-  const { amount, className = '', showUnit = true, size = 'md' } = props;
+  const { amount = 0, showUnit = true, size = 'md', ...rest } = props;
 
   const sizeClasses = {
     sm: 'text-sm',
@@ -26,7 +25,7 @@ export const ZetDisplay: React.FC<ZetDisplayProps> = (props) => {
   const formattedAmount = formatZetAmount(amount);
 
   return (
-    <span className={`${sizeClasses[size]} ${className}`}>
+    <span className={`${sizeClasses[size]} ${rest.className || ''}`} {...rest}>
       {formattedAmount}
       {showUnit && <span className="ml-1">ZET</span>}
     </span>

--- a/src/features/common/components/ZetDisplay/ZetDisplay.tsx
+++ b/src/features/common/components/ZetDisplay/ZetDisplay.tsx
@@ -1,20 +1,11 @@
 import React, { ComponentProps } from 'react';
 
+import { sizeVariants, unitVariants } from './ZetDisplayVariants';
+
 type ZetDisplayProps = ComponentProps<'span'> & {
   amount?: number;
   showUnit?: boolean;
   size?: 'sm' | 'md' | 'lg';
-};
-
-// 조건부 스타일링을 위한 객체들
-const sizeClassesMap = {
-  sm: 'text-sm',
-  md: 'text-base',
-  lg: 'text-lg',
-};
-
-const unitStyleMap = {
-  base: 'ml-1',
 };
 
 export const formatZetAmount = (amount: number): string => {
@@ -30,9 +21,9 @@ export const ZetDisplay: React.FC<ZetDisplayProps> = (props) => {
   const formattedAmount = formatZetAmount(amount);
 
   return (
-    <span className={`${sizeClassesMap[size]} ${rest.className || ''}`} {...rest}>
+    <span className={`${sizeVariants({ size })} ${rest.className || ''}`} {...rest}>
       {formattedAmount}
-      {showUnit && <span className={unitStyleMap.base}>ZET</span>}
+      {showUnit && <span className={unitVariants()}>ZET</span>}
     </span>
   );
 };

--- a/src/features/common/components/ZetDisplay/ZetDisplay.tsx
+++ b/src/features/common/components/ZetDisplay/ZetDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, memo } from 'react';
 
 import { sizeVariants, unitVariants } from './ZetDisplayVariants';
 
@@ -15,7 +15,7 @@ export const formatZetAmount = (amount: number): string => {
   return amount.toLocaleString();
 };
 
-export const ZetDisplay: React.FC<ZetDisplayProps> = (props) => {
+export const ZetDisplay = memo<ZetDisplayProps>((props) => {
   const { amount = 0, showUnit = true, size = 'md', ...rest } = props;
 
   const formattedAmount = formatZetAmount(amount);
@@ -26,4 +26,6 @@ export const ZetDisplay: React.FC<ZetDisplayProps> = (props) => {
       {showUnit && <span className={unitVariants()}>ZET</span>}
     </span>
   );
-};
+});
+
+ZetDisplay.displayName = 'ZetDisplay';

--- a/src/features/common/components/ZetDisplay/ZetDisplay.tsx
+++ b/src/features/common/components/ZetDisplay/ZetDisplay.tsx
@@ -6,6 +6,17 @@ type ZetDisplayProps = ComponentProps<'span'> & {
   size?: 'sm' | 'md' | 'lg';
 };
 
+// 조건부 스타일링을 위한 객체들
+const sizeClassesMap = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+};
+
+const unitStyleMap = {
+  base: 'ml-1',
+};
+
 export const formatZetAmount = (amount: number): string => {
   if (amount >= 99999) {
     return '99,999+';
@@ -16,18 +27,12 @@ export const formatZetAmount = (amount: number): string => {
 export const ZetDisplay: React.FC<ZetDisplayProps> = (props) => {
   const { amount = 0, showUnit = true, size = 'md', ...rest } = props;
 
-  const sizeClasses = {
-    sm: 'text-sm',
-    md: 'text-base',
-    lg: 'text-lg',
-  };
-
   const formattedAmount = formatZetAmount(amount);
 
   return (
-    <span className={`${sizeClasses[size]} ${rest.className || ''}`} {...rest}>
+    <span className={`${sizeClassesMap[size]} ${rest.className || ''}`} {...rest}>
       {formattedAmount}
-      {showUnit && <span className="ml-1">ZET</span>}
+      {showUnit && <span className={unitStyleMap.base}>ZET</span>}
     </span>
   );
 };

--- a/src/features/common/components/ZetDisplay/ZetDisplay.tsx
+++ b/src/features/common/components/ZetDisplay/ZetDisplay.tsx
@@ -14,12 +14,9 @@ export const formatZetAmount = (amount: number): string => {
   return amount.toLocaleString();
 };
 
-export const ZetDisplay: React.FC<ZetDisplayProps> = ({
-  amount,
-  className = '',
-  showUnit = true,
-  size = 'md',
-}) => {
+export const ZetDisplay: React.FC<ZetDisplayProps> = (props) => {
+  const { amount, className = '', showUnit = true, size = 'md' } = props;
+
   const sizeClasses = {
     sm: 'text-sm',
     md: 'text-base',

--- a/src/features/common/components/ZetDisplay/ZetDisplayVariants.ts
+++ b/src/features/common/components/ZetDisplay/ZetDisplayVariants.ts
@@ -1,0 +1,28 @@
+import { cva } from 'class-variance-authority';
+
+export const sizeVariants = cva('', {
+  variants: {
+    size: {
+      sm: 'text-sm',
+      md: 'text-base',
+      lg: 'text-lg',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+// 단위 variants
+export const unitVariants = cva('ml-1', {
+  variants: {
+    variant: {
+      default: '',
+      bold: 'font-bold',
+      muted: 'text-gray-500',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #428 

### 🔎 작업 내용

- [x] ZetDisplay props 구조를 단일 객체 패턴으로 변경
- [x] ComponentProps 적용으로 HTML 속성 자동 지원
- [x] 모든 props를 선택적으로 변경하고 기본값 설정
- [x] cva 기반 variants 시스템으로 스타일링 개선
- [x] React.memo 적용으로 성능 최적화

### 📸 스크린샷 (선택)

### 📢 전달사항
#### 주요 개선사항:
1. 확장성 향상: ComponentProps를 사용하여 HTML 요소의 모든 속성을 자동으로 지원하도록 개선했습니다. 이제 className, style, data-* 속성 등을 별도 정의 없이 사용할 수 있습니다.
2. 타입 안전한 스타일링: class-variance-authority(cva)를 도입하여 타입 안전한 조건부 스타일링 시스템을 구축했습니다. 다양한 3. variant 옵션(size, variant)을 제공하여 유연한 스타일링이 가능합니다.
4. 성능 최적화: React.memo를 적용하여 props가 변경되지 않을 때 불필요한 리렌더링을 방지했습니다.
#### 코드 구조 개선:
- 기존 스타일 맵을 cva variants로 마이그레이션
- ZetDisplayVariants.ts 파일로 스타일 정의 분리
- 관심사 분리로 코드 가독성 향상
- 유지보수성: 스타일 변경 시 한 곳에서만 수정하면 모든 곳에 적용되도록 개선했습니다.
#### 기술적 세부사항:
- ComponentProps<'span'> 상속으로 HTML span 속성 자동 지원
- 모든 props를 선택적으로 변경하여 사용 편의성 향상
- 기본값 설정으로 필수 props 전달 부담 감소
- 스프레드 연산자(...rest) 사용으로 나머지 props 전달
- cva variants로 타입 안전한 조건부 스타일링 구현
- React.memo로 성능 최적화

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?
