### PR TITLE
UF-379 signup 페이지에서는 mypage API 호출 안하도록 변경

### DIFF
--- a/src/features/mypage/hooks/useMyInfo.ts
+++ b/src/features/mypage/hooks/useMyInfo.ts
@@ -5,7 +5,7 @@ import { ApiError } from '@/api/client/axios';
 import { MyInfoResponse } from '@/api/types/myInfo';
 import { queryKeys } from '@/utils';
 
-export function useMyInfo() {
+export function useMyInfo(enabled: boolean = true) {
   return useQuery<MyInfoResponse['content'] | null, unknown>({
     queryKey: queryKeys.myInfo(),
     queryFn: async () => {
@@ -37,5 +37,6 @@ export function useMyInfo() {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     retryOnMount: true,
+    enabled,
   });
 }

--- a/src/shared/layout/TopNav/TopNav.tsx
+++ b/src/shared/layout/TopNav/TopNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 
 import { nextApiRequest } from '@/api/client/axios';
@@ -20,7 +20,9 @@ interface TopNavProps {
 
 const TopNav: React.FC<TopNavProps> = ({ title = 'UFO-Fi', onNotificationClick }) => {
   const router = useRouter();
-  const { data: myInfo, isLoading: isMyInfoLoading } = useMyInfo();
+  const pathname = usePathname();
+  const isSignupPage = pathname.startsWith('/signup');
+  const { data: myInfo, isLoading: isMyInfoLoading } = useMyInfo(!isSignupPage);
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
   const [notifications, setNotifications] = useState<NotificationItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #467

### 🔎 작업 내용

- [x] signup 페이지에서는 mypage API가 호출되지 않도록 변경

### 📸 스크린샷 (선택)
signup 페이지에서는 mypage API 호출이 안됨
<img width="777" height="959" alt="image" src="https://github.com/user-attachments/assets/c7b3b166-3247-4b24-ba7f-9c2bcd4ad9d6" />

main으로 들어오면 mypage API가 기존처럼 호출 잘됨
<img width="763" height="901" alt="image" src="https://github.com/user-attachments/assets/1eec96cc-43e4-4da2-9300-042d49299610" />


### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 회원가입 페이지에서는 사용자 정보가 불필요하게 조회되지 않도록 개선되었습니다.  
* **기능 개선**
  * 사용자 정보 조회 기능이 페이지 상황에 따라 동적으로 동작하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->