### PR TITLE
UF-388 전파 거리 페이지 시멘틱 태그 변경 및 리팩토링&메타데이터 추가 

### DIFF
--- a/src/app/signal/layout.tsx
+++ b/src/app/signal/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'UFO-Fi | 전파궤도',
+  description: 'UFO-Fi의 전파 거리 탐색 페이지',
+  robots: 'index, follow',
+};
+
+export default function SignalLayout({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/src/app/signal/layout.tsx
+++ b/src/app/signal/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'UFO-Fi | 전파궤도',
+  title: 'UFO-Fi | 전파 거리',
   description: 'UFO-Fi의 전파 거리 탐색 페이지',
   robots: 'index, follow',
 };

--- a/src/app/signal/page.tsx
+++ b/src/app/signal/page.tsx
@@ -12,31 +12,39 @@ export default function SignalPage() {
   const [activeTab, setActiveTab] = useState<TabType>('orbit');
 
   return (
-    <div className="flex flex-col">
-      <Title title="전파 거리" />
+    <main className="flex flex-col">
+      <header>
+        <Title title="전파 거리" />
+      </header>
 
-      {/* Tabs UI */}
-      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabType)}>
-        <TabsList className="p-1 mb-6 mx-4 w-auto">
-          <TabsTrigger value="orbit" variant="darkTab" size="full">
-            전파 궤도
-          </TabsTrigger>
-          <TabsTrigger value="letters" variant="darkTab" size="full">
-            편지함
-          </TabsTrigger>
-        </TabsList>
+      <section aria-labelledby="signal-tabs">
+        {/* 탭 선택 영역 */}
+        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabType)}>
+          <TabsList
+            id="signal-tabs"
+            className="p-1 mb-6 mx-4 w-auto"
+            aria-label="전파 궤도와 편지함을 선택하는 탭"
+          >
+            <TabsTrigger value="orbit" variant="darkTab" size="full">
+              전파 궤도
+            </TabsTrigger>
+            <TabsTrigger value="letters" variant="darkTab" size="full">
+              편지함
+            </TabsTrigger>
+          </TabsList>
 
-        {/* 탭 콘텐츠 */}
-        <div className="flex-1">
-          <TabsContent value="orbit">
-            <SignalTabContent />
-          </TabsContent>
+          {/* 탭 콘텐츠 */}
+          <div className="flex-1">
+            <TabsContent value="orbit">
+              <SignalTabContent />
+            </TabsContent>
 
-          <TabsContent value="letters">
-            <LetterTabContent />
-          </TabsContent>
-        </div>
-      </Tabs>
-    </div>
+            <TabsContent value="letters">
+              <LetterTabContent />
+            </TabsContent>
+          </div>
+        </Tabs>
+      </section>
+    </main>
   );
 }

--- a/src/features/signal/components/LetterListComponent.tsx
+++ b/src/features/signal/components/LetterListComponent.tsx
@@ -8,28 +8,30 @@ import { LetterDisplay } from '@/backend/types/letters';
 import { Button, Loading } from '@/shared';
 import { useLetterStore } from '@/stores/useLetterStore';
 
-type Letter = LetterDisplay;
+// 메시지 상수
+const MESSAGE = {
+  LOADING: '항해 편지를 불러오고 있어요...',
+  ERROR: '편지를 불러오지 못했습니다. 다시 시도해주세요.',
+  EMPTY: '아직 항해 편지가 없어요.',
+};
 
 export default function LetterListComponent() {
-  const [letters, setLetters] = useState<Letter[]>([]);
+  const [letters, setLetters] = useState<LetterDisplay[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { setLetterCount } = useLetterStore();
 
   const loadLetters = useCallback(async () => {
     try {
-      //편지 불러오기 시작
       setIsLoading(true);
       setError(null);
 
       const { letters: fetchedLetters, count } = await fetchLetters();
-      // 편지 불러오기 성공해서 상태 업데이트
       setLetters(fetchedLetters);
       setLetterCount(count);
     } catch {
-      // 편지 불러오기 실패
-      setError('편지를 불러오지 못했습니다...');
-      toast.error('편지를 불러오지 못했습니다. 다시 시도해주세요.');
+      setError(MESSAGE.ERROR);
+      toast.error(MESSAGE.ERROR);
     } finally {
       setIsLoading(false);
     }
@@ -39,16 +41,14 @@ export default function LetterListComponent() {
     loadLetters();
   }, [loadLetters]);
 
-  // 로딩 중일 때 시그널 로딩 화면 표시
   if (isLoading) {
     return (
       <div className="h-full flex items-center justify-center">
-        <Loading variant="signal" message="항해 편지를 불러오고 있어요..." className="p-8" />
+        <Loading variant="signal" message={MESSAGE.LOADING} className="p-8" />
       </div>
     );
   }
 
-  // 에러 발생 시
   if (error) {
     return (
       <div className="p-4 text-center">
@@ -61,20 +61,20 @@ export default function LetterListComponent() {
   }
 
   if (letters.length === 0) {
-    return <p className="p-4">아직 항해 편지가 없어요.</p>;
+    return <p className="p-4 text-gray-400">{MESSAGE.EMPTY}</p>;
   }
 
   return (
-    <div className="space-y-4 p-4">
+    <section aria-label="탐사 편지 목록" className="space-y-4 p-4">
       {letters.map((letter) => (
-        <div
+        <article
           key={letter.step}
           className="bg-black border-l-4 border-indigo-400 p-4 rounded shadow cursor-pointer"
         >
           <p className="text-sm text-gray-500">행성 {letter.step}단계</p>
           <p>{letter.content}</p>
-        </div>
+        </article>
       ))}
-    </div>
+    </section>
   );
 }

--- a/src/features/signal/components/LetterTabContent.tsx
+++ b/src/features/signal/components/LetterTabContent.tsx
@@ -3,13 +3,16 @@ import SignalProgressBar from './SignalProgressBar';
 
 export default function LetterTabContent() {
   return (
-    <div className="w-full h-full flex flex-col justify-center items-center space-y-4">
-      <div className="z-30 scale-85">
+    <section
+      aria-label="전파거리 관련 탭 콘텐츠"
+      className="w-full h-full flex flex-col justify-center items-center space-y-4"
+    >
+      <div className="z-30 scale-90">
         <SignalProgressBar />
       </div>
-      <div>
+      <article>
         <LetterComponent />
-      </div>
-    </div>
+      </article>
+    </section>
   );
 }

--- a/src/features/signal/components/PlanetComponent.tsx
+++ b/src/features/signal/components/PlanetComponent.tsx
@@ -1,7 +1,9 @@
 import Image from 'next/image';
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
-interface PlanetComponentProps {
+const SATELLITE_SIZE = 30;
+
+interface PlanetComponentProps extends ComponentProps<'div'> {
   planetSrc: string;
   satelliteSrc: string;
   planetSize: number;
@@ -9,25 +11,27 @@ interface PlanetComponentProps {
 }
 
 const PlanetComponent = React.forwardRef<HTMLDivElement, PlanetComponentProps>(
-  ({ planetSrc, satelliteSrc, planetSize, isArrived }, ref) => {
+  ({ planetSrc, satelliteSrc, planetSize, isArrived, className = '', ...rest }, ref) => {
     return (
       <div
         ref={ref}
-        className="relative flex flex-col items-center z-10"
-        style={{ minWidth: planetSize, height: planetSize }}
+        className={`relative flex flex-col items-center z-10 ${className}`}
+        style={{
+          minWidth: planetSize,
+          height: planetSize,
+        }}
+        {...rest}
       >
-        {/* 도착한 경우에만 위성 표시 */}
         {isArrived && (
           <Image
             src={satelliteSrc}
             alt="위성"
-            width={30}
-            height={30}
+            width={SATELLITE_SIZE}
+            height={SATELLITE_SIZE}
             className="absolute top-[-12px]"
           />
         )}
 
-        {/* 행성 이미지 - 도착 여부에 따라 흑백/컬러 처리 */}
         <Image
           src={planetSrc}
           alt="행성"

--- a/src/features/signal/components/PlanetWithSatellite.tsx
+++ b/src/features/signal/components/PlanetWithSatellite.tsx
@@ -1,33 +1,36 @@
 import Image from 'next/image';
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
-interface PlanetComponentProps {
+const SATELLITE_SIZE = 30;
+const SATELLITE_OFFSET_TOP = -35;
+
+interface PlanetWithSatelliteProps extends ComponentProps<'div'> {
   planetSrc: string;
   satelliteSrc: string;
   planetSize: number;
   isArrived: boolean;
 }
 
-const PlanetWithSatellite = React.forwardRef<HTMLDivElement, PlanetComponentProps>(
-  ({ planetSrc, satelliteSrc, planetSize, isArrived }, ref) => {
+const PlanetWithSatellite = React.forwardRef<HTMLDivElement, PlanetWithSatelliteProps>(
+  ({ planetSrc, satelliteSrc, planetSize, isArrived, className = '', ...rest }, ref) => {
     return (
       <div
         ref={ref}
-        className="relative flex flex-col items-center z-10"
+        className={`relative flex flex-col items-center z-10 ${className}`}
         style={{ minWidth: planetSize, height: planetSize }}
+        {...rest}
       >
         {/* 도착한 경우에만 위성 표시 */}
         {isArrived && (
           <Image
             src={satelliteSrc}
             alt="위성"
-            width={30}
-            height={30}
-            className="absolute top-[-35px]"
+            width={SATELLITE_SIZE}
+            height={SATELLITE_SIZE}
+            className={`absolute top-[${SATELLITE_OFFSET_TOP}px]`}
           />
         )}
 
-        {/* 행성 이미지 - 도착 여부에 따라 흑백/컬러 처리 */}
         <Image
           src={planetSrc}
           alt="행성"

--- a/src/features/signal/components/PlanetWithSatellite.tsx
+++ b/src/features/signal/components/PlanetWithSatellite.tsx
@@ -27,7 +27,8 @@ const PlanetWithSatellite = React.forwardRef<HTMLDivElement, PlanetWithSatellite
             alt="위성"
             width={SATELLITE_SIZE}
             height={SATELLITE_SIZE}
-            className={`absolute top-[${SATELLITE_OFFSET_TOP}px]`}
+            className="absolute"
+            style={{ top: `${SATELLITE_OFFSET_TOP}px` }}
           />
         )}
 

--- a/src/features/signal/components/SignalProgressBar.tsx
+++ b/src/features/signal/components/SignalProgressBar.tsx
@@ -7,6 +7,8 @@ import { useLetters } from '@/hooks/useLetters';
 
 import PlanetWithSatellite from './PlanetWithSatellite';
 
+const PLANET_SIZE = 60;
+
 export default function SignalProgressBar() {
   const PLANETS = [
     IMAGE_PATHS.PLANET_1,
@@ -24,25 +26,20 @@ export default function SignalProgressBar() {
     IMAGE_PATHS.SATELLITE_5,
   ];
 
-  // 전역 상태에서 행성 도달 상태 가져오기
   const { planetStatus, completedPlanets, initializeLetters } = useLetters();
 
-  // 컴포넌트 마운트 시 편지 상태 로드하기
   useEffect(() => {
     initializeLetters();
   }, [initializeLetters]);
 
-  // 도달한 행성의 개수 계산
-  const completed = completedPlanets;
-
   return (
-    <div className="flex flex-col items-center w-full gap-4 px-4">
+    <section aria-label="탐사 진행 현황" className="flex flex-col items-center w-full gap-4 px-4">
       {/* 진행 텍스트 */}
-      <p className="text-white text-md pyeongchangpeace-title-2 mb-5">
-        {completed}번째 은하까지 탐사 완료...
+      <p className="text-white text-md pyeongchangpeace-title-2 mb-5" aria-live="polite">
+        {completedPlanets}번째 은하까지 탐사 완료...
       </p>
 
-      {/* 선 + 행성 */}
+      {/* 선 + 행성 아이콘 */}
       <div className="relative flex items-center justify-center w-full">
         {/* 가운데 점선 선 */}
         <div className="absolute inset-x-4 top-1/2 rounded-full border border-dashed border-gray-400 -translate-y-1/2" />
@@ -54,15 +51,17 @@ export default function SignalProgressBar() {
               key={index}
               planetSrc={planet}
               satelliteSrc={SATELLITES[index]}
-              planetSize={60}
+              planetSize={PLANET_SIZE}
               isArrived={planetStatus[index]}
             />
           ))}
         </div>
-        <div className="flex items-center justify-center size-12 rounded-full bg-[#222] text-white text-sm ml-3 relative z-10 flex-shrink-0">
-          {completed}/{PLANETS.length}
+
+        {/* 진행 상태 카운터 */}
+        <div className="flex items-center justify-center size-12 rounded-full bg-neutral-900 text-white text-sm ml-3 relative z-10 flex-shrink-0">
+          {completedPlanets}/{PLANETS.length}
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/features/signal/components/SignalProgressBar.tsx
+++ b/src/features/signal/components/SignalProgressBar.tsx
@@ -58,7 +58,10 @@ export default function SignalProgressBar() {
         </div>
 
         {/* 진행 상태 카운터 */}
-        <div className="flex items-center justify-center size-12 rounded-full bg-[#222] text-white text-sm ml-3 relative z-10 flex-shrink-0">
+        <div
+          className="flex items-center justify-center size-12 rounded-full text-white text-sm ml-3 relative z-10 flex-shrink-0"
+          style={{ backgroundColor: '#222' }}
+        >
           {completedPlanets}/{PLANETS.length}
         </div>
       </div>

--- a/src/features/signal/components/SignalProgressBar.tsx
+++ b/src/features/signal/components/SignalProgressBar.tsx
@@ -58,7 +58,7 @@ export default function SignalProgressBar() {
         </div>
 
         {/* 진행 상태 카운터 */}
-        <div className="flex items-center justify-center size-12 rounded-full bg-neutral-900 text-white text-sm ml-3 relative z-10 flex-shrink-0">
+        <div className="flex items-center justify-center size-12 rounded-full bg-[#222] text-white text-sm ml-3 relative z-10 flex-shrink-0">
           {completedPlanets}/{PLANETS.length}
         </div>
       </div>

--- a/src/features/signal/constants/layoutConfig.ts
+++ b/src/features/signal/constants/layoutConfig.ts
@@ -1,0 +1,12 @@
+export const CONTAINER_WIDTH = 860;
+export const CONTAINER_HEIGHT = 675;
+
+export const PLANET_POSITIONS = [
+  { top: 36, left: 36 },
+  { top: 200, left: 170 },
+  { top: 440, left: 390 },
+  { top: 50, left: 500 },
+  { top: 180, left: 740 },
+];
+
+export const PLANET_SIZES = [145, 185, 145, 195, 120];

--- a/src/features/signal/constants/layoutConfig.ts
+++ b/src/features/signal/constants/layoutConfig.ts
@@ -1,12 +1,17 @@
+export interface PlanetPosition {
+  top: number;
+  left: number;
+}
+
 export const CONTAINER_WIDTH = 860;
 export const CONTAINER_HEIGHT = 675;
 
-export const PLANET_POSITIONS = [
+export const PLANET_POSITIONS: readonly PlanetPosition[] = [
   { top: 36, left: 36 },
   { top: 200, left: 170 },
   { top: 440, left: 390 },
   { top: 50, left: 500 },
   { top: 180, left: 740 },
-];
+] as const;
 
-export const PLANET_SIZES = [145, 185, 145, 195, 120];
+export const PLANET_SIZES: readonly number[] = [145, 185, 145, 195, 120] as const;


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #483 

### 🔎 작업 내용

- [x] 기존 div 구조 → main, section, article, header 등 시맨틱 태그로 교체
- [x] 메타데이터 추가

### 📸 스크린샷 (선택)
<img width="191" height="63" alt="image" src="https://github.com/user-attachments/assets/9abb06dc-e303-4967-a7eb-9a5c6fb261cc" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 시그널 페이지에 대한 레이아웃 및 메타데이터가 추가되었습니다.
  * 시그널 기능의 레이아웃 구성을 위한 고정 상수 파일이 도입되었습니다.

* **리팩터링**
  * 시그널 관련 컴포넌트 전반에 걸쳐 시맨틱 HTML 태그 적용 및 접근성(ARIA) 속성 개선이 이루어졌습니다.
  * 사용자 메시지(로딩, 오류, 비어있음 등)가 상수로 통합되어 관리됩니다.
  * 레이아웃 및 스타일 관련 값이 하드코딩에서 상수 참조 방식으로 변경되었습니다.
  * 일부 컴포넌트는 props 확장으로 더 유연하게 속성을 전달받을 수 있습니다.

* **스타일**
  * 시그널 관련 컴포넌트의 구조 및 스타일이 일관성 있게 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->