### PR TITLE
UF-392 SellingItem 컴포넌트 디자인, 레이아웃 변경

### DIFF
--- a/src/features/exchange/components/SellingItem.tsx
+++ b/src/features/exchange/components/SellingItem.tsx
@@ -56,12 +56,12 @@ export default function SellingItem({
   const carrierIcon = getCarrierIcon(carrier);
 
   return (
-    <div className="relative w-full max-w-[180px] sm:max-w-[196px] mb-8">
+    <div className="relative w-full max-w-[170px] sm:max-w-[190px] mb-8">
       {/* 카드 본체 */}
-      <div className="relative z-10 p-3 rounded-2xl bg-[#0E213F] shadow-md border border-[#175F89] flex flex-col min-h-[240px]">
+      <div className="relative z-10 p-3 rounded-2xl bg-[#0E213F] shadow-md border border-[#175F89] flex flex-col min-h-[200px]">
         {/* 뱃지들 */}
-        <div className="flex justify-between items-center mb-3">
-          <div className="flex gap-1">
+        <div className="flex gap-1 justify-between items-center mb-2">
+          <div className="flex items-center gap-1">
             <Badge showIcon={false} variant="carrier" className="text-[9px] px-2 py-0.5">
               {carrierIcon && (
                 <Image
@@ -69,22 +69,20 @@ export default function SellingItem({
                   alt={carrier}
                   width={12}
                   height={12}
-                  className="inline-block w-3 h-3 mr-1"
+                  className="inline-block w-3 h-3"
                 />
               )}
-              {carrier}
             </Badge>
             <Badge showIcon={false} variant="secondary" className="text-[9px] px-2 py-0.5">
               {networkType}
             </Badge>
           </div>
+          {/* 시간 영역 */}
+          <span className="text-gray-400 text-[12px] text-right">{timeLeft}</span>
         </div>
 
-        {/* 시간 영역 */}
-        <span className="text-gray-400 text-[12px] text-right">{timeLeft}</span>
-
         {/* 프로필 영역 - 클릭 시 프로필 페이지로 이동 */}
-        <div className="mb-3">
+        <div className="mb-2">
           <UserLink userId={sellerId} nickname={sellerNickname} className="flex items-center gap-2">
             <div className="size-10 rounded-full overflow-hidden border border-cyan-400/30 hover:border-cyan-400 transition-colors flex-shrink-0">
               <Image
@@ -105,20 +103,20 @@ export default function SellingItem({
         </div>
 
         {/* 글 제목 */}
-        <div className="mb-3">
+        <div className="mb-2">
           <span className="text-white text-sm font-semibold line-clamp-1 leading-tight">
             {title}
           </span>
         </div>
 
         {/* 용량 + 가격 */}
-        <div className="flex justify-between items-baseline mb-4">
-          <span className="text-white text-base font-bold">{capacity}</span>
-          <span className="text-cyan-300 text-base font-bold">{price}</span>
+        <div className="flex justify-between items-baseline mb-2">
+          <span className="text-white text-lg font-bold">{capacity}</span>
+          <span className="text-cyan-300 text-lg font-bold">{price}</span>
         </div>
 
         {/* 구매/관리 버튼 */}
-        <div className="flex justify-end items-center gap-1">
+        <div className="flex justify-between items-center gap-1 mt-auto">
           {!isOwner ? (
             <>
               <Button
@@ -168,9 +166,9 @@ export default function SellingItem({
       <Image
         src={IMAGE_PATHS.STONE}
         alt="stone"
-        width={220}
+        width={260}
         height={60}
-        className="absolute bottom-[-1.75rem] left-1/2 -translate-x-1/2 z-0 scale-[0.9]"
+        className="absolute bottom-[-2rem] left-1/2 -translate-x-1/2 z-0 "
       />
     </div>
   );


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #491

### 🔎 작업 내용

- [x] SellingItem 컴포넌트 디자인, 레이아웃 수정

### 📸 스크린샷 (선택)
<img width="591" height="844" alt="image" src="https://github.com/user-attachments/assets/5ecc9534-dfe6-4c72-93eb-76a4f2d62841" />

<img width="368" height="805" alt="image" src="https://github.com/user-attachments/assets/b277856e-cc43-4b56-b9a4-46ac8b6339da" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 판매 아이템 카드의 크기, 여백, 폰트 크기 등 레이아웃이 조정되어 더욱 깔끔하고 보기 쉽게 개선되었습니다.
  * 뱃지와 남은 시간 표시가 한 줄로 정렬되고, 일부 텍스트와 아이콘 간격이 조정되었습니다.
  * 하단 석재 이미지가 더 크게 표시되고 위치가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->