### PR TITLE
UF-394 백오피스 제트 복구 페이지 ui 구현 

### DIFF
--- a/src/app/admin/zet-recovery/page.tsx
+++ b/src/app/admin/zet-recovery/page.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { Header, Sidebar } from '@/shared';
+
+export default function ZetRecoveryPage() {
+  const [userId, setUserId] = useState('');
+  const [zetAmount, setZetAmount] = useState('');
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleSubmit = async () => {
+    const userIdNum = parseInt(userId);
+    const zetAmountNum = parseInt(zetAmount);
+
+    if (!userIdNum || userIdNum <= 0) {
+      toast.error('올바른 사용자 ID를 입력해주세요.');
+      return;
+    }
+
+    if (!zetAmountNum || zetAmountNum <= 0) {
+      toast.error('올바른 ZET 금액을 입력해주세요.');
+      return;
+    }
+
+    setIsProcessing(true);
+
+    // 더미 처리 (실제로는 API 호출)
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 1500)); // 더미 딜레이
+      toast.success(
+        `사용자 ID ${userIdNum}에게 ${zetAmountNum.toLocaleString()} ZET 복구가 완료되었습니다.`,
+      );
+      setUserId('');
+      setZetAmount('');
+    } catch {
+      toast.error('복구 처리 중 오류가 발생했습니다.');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const isFormValid =
+    userId && zetAmount && !isNaN(parseInt(userId)) && !isNaN(parseInt(zetAmount));
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <div className="hidden lg:block">
+        <Sidebar />
+      </div>
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <Header userName="Admin" />
+        <main className="flex-1 overflow-y-auto p-4 lg:p-8">
+          <div className="max-w-7xl mx-auto">
+            <h1 className="text-2xl font-bold text-gray-900 mb-6">ZET 복구 관리</h1>
+            <div className="max-w-2xl">
+              <div className="bg-white rounded-lg shadow">
+                <div className="p-6">
+                  <h2 className="text-lg font-medium text-gray-900 mb-6">ZET 복구 처리</h2>
+
+                  <div className="space-y-6">
+                    {/* 사용자 ID 입력 */}
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                        사용자 ID
+                      </label>
+                      <input
+                        type="number"
+                        value={userId}
+                        onChange={(e) => setUserId(e.target.value)}
+                        placeholder="사용자 ID를 입력하세요"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                      />
+                    </div>
+
+                    {/* 복구할 ZET 금액 입력 */}
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                        복구할 ZET 금액
+                      </label>
+                      <input
+                        type="number"
+                        value={zetAmount}
+                        onChange={(e) => setZetAmount(e.target.value)}
+                        placeholder="복구할 ZET 금액을 입력하세요"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                      />
+                    </div>
+
+                    {/* 확인 버튼 */}
+                    <div className="flex justify-end">
+                      <button
+                        onClick={handleSubmit}
+                        disabled={!isFormValid || isProcessing}
+                        className={`px-6 py-2 rounded-md font-medium ${
+                          isFormValid && !isProcessing
+                            ? 'bg-indigo-600 hover:bg-indigo-700 text-white'
+                            : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                        }`}
+                      >
+                        {isProcessing ? '처리 중...' : 'ZET 복구하기'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/components/AdminSideMenu/AdminSideMenu.tsx
+++ b/src/features/admin/components/AdminSideMenu/AdminSideMenu.tsx
@@ -55,6 +55,12 @@ const menuItems: MenuItem[] = [
     href: '/admin/banned-words',
   },
   {
+    id: 'zet-recovery',
+    label: 'ZET 복구',
+    icon: 'CreditCard',
+    href: '/admin/zet-recovery',
+  },
+  {
     id: 'settings',
     label: '시스템 설정',
     icon: 'Settings',

--- a/src/shared/ui/Icons/Icons.types.ts
+++ b/src/shared/ui/Icons/Icons.types.ts
@@ -78,6 +78,7 @@ export type LucideIconType =
   | 'UserCheck'
   | 'Users'
   | 'Focus'
+  | 'CreditCard'
   | 'ArrowUp';
 
 // 커스텀 아이콘 타입

--- a/src/shared/ui/Sidebar/Sidebar.tsx
+++ b/src/shared/ui/Sidebar/Sidebar.tsx
@@ -55,6 +55,12 @@ const menuItems: MenuItem[] = [
     href: '/admin/banned-words',
   },
   {
+    id: 'zet-recovery',
+    label: 'ZET 복구',
+    icon: 'CreditCard',
+    href: '/admin/zet-recovery',
+  },
+  {
     id: 'settings',
     label: '시스템 설정',
     icon: 'Settings',


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #494

### 🔎 작업 내용

- [x] 백오피스 제트 복구 페이지 ui 구현 
- [ ] 추후 API 들어오면 바로 연동해야 함

### 📸 스크린샷 (선택)
<img width="1080" height="530" alt="image" src="https://github.com/user-attachments/assets/df641231-0013-45c0-b5da-12cce9c1f8c2" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 인터페이스에 ZET 복구 페이지가 추가되었습니다. 사용자는 유저 ID와 ZET 수량을 입력하여 복구 요청을 할 수 있습니다.
  * 사이드바 및 관리자 메뉴에 "ZET 복구" 항목이 추가되어 해당 페이지로 쉽게 이동할 수 있습니다.

* **UI 개선**
  * "ZET 복구" 메뉴에 새로운 아이콘이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->