### PR TITLE
UF-411 레이아웃 & 토스트 위치 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body
-        className={`${pretendard.className} antialiased min-h-screen bg-transparent`}
+        className={`${pretendard.className} antialiased bg-transparent`}
         style={
           {
             '--font-pyeongchangpeace-bold': 'PyeongChangPeace-Bold',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import PlanetProgressBar from '@/features/main/components/PlanetProgressBar';
 
 export default function HomePage() {
   return (
-    <div className="w-full min-h-full flex flex-col">
+    <div className="w-full h-full flex flex-col">
       <div className="flex-1 flex items-center justify-center">
         <OrbitWithSatellite />
       </div>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -23,23 +23,21 @@ interface ProvidersProps {
  */
 export default function Providers({ children }: ProvidersProps) {
   return (
-    <>
+    <ToastProvider>
       <AnalyticsProvider />
       <QueryProvider>
         <ViewportObserverProvider>
           <AppLayoutProvider>
             <AuthProvider>
               <FCMProvider>
-                <ToastProvider>
-                  {children}
-                  <Analytics />
-                </ToastProvider>
+                {children}
+                <Analytics />
               </FCMProvider>
             </AuthProvider>
           </AppLayoutProvider>
           <ModalProvider />
         </ViewportObserverProvider>
       </QueryProvider>
-    </>
+    </ToastProvider>
   );
 }

--- a/src/provider/AppLayoutProvider.tsx
+++ b/src/provider/AppLayoutProvider.tsx
@@ -130,9 +130,11 @@ export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
           {!isNavigationHidden && (
             <div
               className="fixed bottom-0 left-0 w-full z-40"
-              style={{ height: `${BOTTOM_NAV_HEIGHT}px` }}
-              onTouchStart={(e) => e.preventDefault()}
-              onTouchMove={(e) => e.preventDefault()}
+              style={{
+                height: `${BOTTOM_NAV_HEIGHT}px`,
+                overscrollBehavior: 'contain',
+                touchAction: 'manipulation', // 터치 스크롤만 제어
+              }}
             >
               <BottomNav />
             </div>

--- a/src/provider/ToastProvider.tsx
+++ b/src/provider/ToastProvider.tsx
@@ -1,46 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
 import { Toaster } from 'sonner';
 
-export function ToastProvider({ children }: { children: React.ReactNode }) {
-  useEffect(() => {
-    const adjustToasterPosition = () => {
-      const toaster = document.querySelector('[data-sonner-toaster]') as HTMLElement | null;
-      if (!toaster) return;
-
-      toaster.style.bottom = '100px';
-      toaster.style.position = 'fixed';
-      toaster.style.zIndex = '9999';
-    };
-
-    // 최초 렌더 완료 대기 후 적용
-    const waitForToaster = () => {
-      const toaster = document.querySelector('[data-sonner-toaster]');
-      if (toaster) {
-        adjustToasterPosition();
-      } else {
-        requestAnimationFrame(waitForToaster);
-      }
-    };
-    waitForToaster();
-
-    // 리사이즈 시 보정
-    window.addEventListener('resize', adjustToasterPosition);
-
-    // 부모 DOM 변경 시 위치 보정
-    const toasterContainer = document.querySelector('[data-sonner-toaster]')?.parentElement;
-    const observer = toasterContainer ? new MutationObserver(adjustToasterPosition) : null;
-    if (observer && toasterContainer) {
-      observer.observe(toasterContainer, { childList: true });
-    }
-
-    return () => {
-      window.removeEventListener('resize', adjustToasterPosition);
-      observer?.disconnect();
-    };
-  }, []);
-
+export function ToastProvider({ children }: { children?: React.ReactNode }) {
   return (
     <>
       {children}
@@ -52,7 +14,21 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
         duration={3000}
         visibleToasts={1}
         containerAriaLabel="알림"
+        offset={50} // BottomNav 위로 50px
+        toastOptions={{
+          style: {
+            marginBottom: '0px',
+          },
+        }}
       />
+      <style jsx global>{`
+        @media (max-width: 768px) {
+          [data-sonner-toaster] {
+            bottom: 60px !important;
+            position: fixed !important;
+          }
+        }
+      `}</style>
     </>
   );
 }

--- a/src/shared/layout/BottomNav/BottomNav.tsx
+++ b/src/shared/layout/BottomNav/BottomNav.tsx
@@ -7,7 +7,6 @@ import { cn } from '@/lib/utils';
 import type { IconType } from '@/shared';
 import { Icon } from '@/shared';
 import { useNavigation } from '@/shared/hooks/useNavigation';
-
 interface NavItem {
   id: string;
   label: string;
@@ -38,52 +37,54 @@ const BottomNav: React.FC<BottomNavProps> = ({ onTabChange }) => {
   };
 
   return (
-    <nav className="bottom-nav-fixed" role="navigation" aria-label="주요 네비게이션">
-      <div className="flex items-center justify-around h-16 w-full">
-        {navItems.map((item) => {
-          const isActive = activeTab === item.id;
-          const isHome = item.id === 'home';
+    <div className="flex flex-col h-full">
+      <nav className="bottom-nav-fixed" role="navigation" aria-label="주요 네비게이션">
+        <div className="flex items-center justify-around h-16 w-full">
+          {navItems.map((item) => {
+            const isActive = activeTab === item.id;
+            const isHome = item.id === 'home';
 
-          return (
-            <div
-              key={item.id}
-              className={cn('flex justify-center items-end h-16', {
-                'relative z-10 w-18 mt-0': isHome,
-                'flex-1': !isHome,
-              })}
-            >
-              <Link
-                href={item.href}
-                onClick={() => handleTabClick(item.id)}
-                className={cn(
-                  'flex flex-col items-center justify-center gap-1 transition-all duration-200 cursor-pointer no-underline',
-                  isHome
-                    ? 'w-full h-[72px] bg-primary-400 rounded-t-3xl'
-                    : 'w-full h-16 hover:bg-white/5 active:scale-95',
-                )}
-                aria-label={item.label}
-                aria-current={isActive ? 'page' : undefined}
+            return (
+              <div
+                key={item.id}
+                className={cn('flex justify-center items-end h-16', {
+                  'relative z-10 w-18 mt-0': isHome,
+                  'flex-1': !isHome,
+                })}
               >
-                <Icon
-                  name={item.icon}
-                  size={isHome ? 'lg' : 'md'}
-                  color={isActive ? 'var(--color-secondary-yellow)' : 'white'}
-                  className={isActive ? 'text-yellow-400' : 'text-white'}
-                />
-                <span
+                <Link
+                  href={item.href}
+                  onClick={() => handleTabClick(item.id)}
                   className={cn(
-                    'text-xs font-bold leading-none transition-colors',
-                    isActive ? 'text-yellow-400' : 'text-white/70',
+                    'flex flex-col items-center justify-center gap-1 transition-all duration-200 cursor-pointer no-underline',
+                    isHome
+                      ? 'w-full h-[72px] bg-primary-400 rounded-t-3xl'
+                      : 'w-full h-16 hover:bg-white/5 active:scale-95',
                   )}
+                  aria-label={item.label}
+                  aria-current={isActive ? 'page' : undefined}
                 >
-                  {item.label}
-                </span>
-              </Link>
-            </div>
-          );
-        })}
-      </div>
-    </nav>
+                  <Icon
+                    name={item.icon}
+                    size={isHome ? 'lg' : 'md'}
+                    color={isActive ? 'var(--color-secondary-yellow)' : 'white'}
+                    className={isActive ? 'text-yellow-400' : 'text-white'}
+                  />
+                  <span
+                    className={cn(
+                      'text-xs font-bold leading-none transition-colors',
+                      isActive ? 'text-yellow-400' : 'text-white/70',
+                    )}
+                  >
+                    {item.label}
+                  </span>
+                </Link>
+              </div>
+            );
+          })}
+        </div>
+      </nav>
+    </div>
   );
 };
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -293,7 +293,6 @@
     overscroll-behavior: none !important;
     touch-action: manipulation;
     overflow: hidden;
-    overscroll-behavior: none;
     touch-action: none; /* iOS 터치 스크롤 방지 */
   }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -259,8 +259,30 @@
     box-sizing: border-box;
   }
 
+  /* 전역 스크롤 방지 */
+  html,
+  body,
+  #__next,
+  [data-nextjs-scroll-focus-boundary] {
+    height: 100% !important;
+    overflow: hidden !important;
+    position: fixed !important;
+    width: 100% !important;
+    top: 0 !important;
+    left: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    max-height: 100vh !important;
+    min-height: unset !important;
+  }
+
+  /* 페이지 레벨 컨테이너의 min-height만 제한 */
+  body > div,
+  body > div > div {
+    min-height: unset !important;
+  }
+
   html {
-    height: -webkit-fill-available;
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;
   }
@@ -268,13 +290,37 @@
   body {
     @apply bg-background text-foreground;
     line-height: 1.6;
-    overscroll-behavior: none;
+    overscroll-behavior: none !important;
     touch-action: manipulation;
-    min-height: 100vh;
-    min-height: -webkit-fill-available;
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
+  }
+
+  /* 아이폰 Safari 전용 추가 스크롤 방지 */
+  @supports (-webkit-touch-callout: none) {
+    /* iOS Safari에서만 적용 */
+    html,
+    body {
+      -webkit-overflow-scrolling: auto !important;
+      overscroll-behavior-y: none !important;
+      overscroll-behavior-x: none !important;
+    }
+
+    body {
+      position: relative !important;
+      -webkit-transform: translate3d(0, 0, 0) !important;
+      transform: translate3d(0, 0, 0) !important;
+    }
+  }
+
+  /* 모든 스크롤 방지 */
+  html,
+  body {
+    -webkit-overflow-scrolling: touch;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  html::-webkit-scrollbar,
+  body::-webkit-scrollbar {
+    display: none;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -292,6 +292,9 @@
     line-height: 1.6;
     overscroll-behavior: none !important;
     touch-action: manipulation;
+    overflow: hidden;
+    overscroll-behavior: none;
+    touch-action: none; /* iOS 터치 스크롤 방지 */
   }
 
   /* 아이폰 Safari 전용 추가 스크롤 방지 */


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #516 

### 🔎 작업 내용

- [x] 상단, 하단 Nav를 제외한 가운데 영역에만 스크롤이 가능하도록 변경 (모바일 화면에서는 주소줄, 하단 도구모음이 사라지지 않아야하기때문에)
- [x] 토스트 위치 수정

### 📸 스크린샷 (선택)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d24b3a59-4ebf-43d9-abc3-ebe5a72bea08" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/090e673c-3879-439f-af88-10e430f3f407" />



### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 글로벌 스크롤 방지 스타일이 적용되어, 모든 브라우저 및 iOS Safari에서 스크롤이 차단됩니다.
  * 레이아웃 및 컨테이너의 높이, 배경, 오버플로우 관련 CSS 클래스가 일부 변경되어 화면 배치가 더 일관되게 조정됩니다.
  * BottomNav가 고정 위치로 감싸져 하단 내비게이션이 항상 화면 하단에 위치합니다.
  * Toast 알림이 하단 내비게이션 위에 적절히 표시되도록 위치와 스타일이 개선되었습니다.

* **리팩터**
  * 레이아웃 및 프로바이더 구조가 단순화되어 불필요한 조건문과 중복된 래퍼가 제거되었습니다.

* **버그 수정**
  * 토스트 알림 위치 조정 및 스크롤 방지로 인해 레이아웃 깨짐 및 스크롤 관련 이슈가 해결되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->