### PR TITLE
UF-419 거래소 Refetch 및 profile/datalist layout 추가

### DIFF
--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -27,6 +27,9 @@ export default function ExchangePage() {
   const refetchExchangeData = () => {
     refetchList();
     queryClient.invalidateQueries({
+      queryKey: queryKeys.exchangePostsInfinite(),
+    });
+    queryClient.invalidateQueries({
       queryKey: queryKeys.myInfo(),
     });
   };

--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -21,6 +21,15 @@ export default function ExchangePage() {
   const [reportModal, setReportModal] = useState({ isOpen: false, postId: 0, sellerId: 0 });
   const [isDeleting, setIsDeleting] = useState(false);
   const [isPurchaseLoading, setIsPurchaseLoading] = useState(false);
+  const [refetchList, setRefetchList] = useState<() => void>(() => () => {});
+
+  // 캐시 무효화
+  const refetchExchangeData = () => {
+    refetchList();
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.myInfo(),
+    });
+  };
 
   // 수정 핸들러
   const handleEdit = (id: number) => {
@@ -101,12 +110,7 @@ export default function ExchangePage() {
       setDeleteModal({ isOpen: false, postId: 0 });
 
       // 캐시 무효화
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.exchangePostsInfinite(),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.myInfo(),
-      });
+      refetchExchangeData();
     } catch (error) {
       console.error('Delete error:', error);
       toast.error('삭제 중 오류가 발생했습니다.');
@@ -142,6 +146,7 @@ export default function ExchangePage() {
             onReport={handleReport}
             onPurchase={handlePurchase}
             purchaseLoading={isPurchaseLoading}
+            onRefetch={(refetchFunction) => setRefetchList(() => refetchFunction)}
           />
         </section>
       </main>
@@ -164,6 +169,7 @@ export default function ExchangePage() {
         onClose={handleCancelReport}
         postId={reportModal.postId}
         postOwnerUserId={reportModal.sellerId}
+        onSuccess={refetchExchangeData}
       />
     </div>
   );

--- a/src/app/profile/[userId]/datalist/layout.tsx
+++ b/src/app/profile/[userId]/datalist/layout.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from 'next';
+
+import { profileAPI } from '@/backend';
+import { IMAGE_PATHS } from '@/constants/images';
+
+interface Props {
+  params: { userId: string };
+  children: React.ReactNode;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  try {
+    const { userId } = await params;
+    const userIdNumber = Number(userId);
+
+    if (isNaN(userIdNumber) || userIdNumber <= 0) {
+      throw new Error('Invalid userId');
+    }
+
+    const profile = await profileAPI.getProfileData(userIdNumber);
+
+    const title = `${profile.nickname}님의 판매 데이터`;
+    const description = `${profile.nickname}님의 UFO-Fi 판매중인 데이터를 확인해보세요.`;
+    const datalistUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/profile/${params.userId}/datalist`;
+    const imageUrl = profile.profileImageUrl || IMAGE_PATHS.AVATAR;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        url: datalistUrl,
+        images: [imageUrl],
+        siteName: 'UFO-Fi',
+        type: 'profile',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+        images: [imageUrl],
+      },
+      alternates: {
+        canonical: datalistUrl,
+      },
+    };
+  } catch {
+    return {
+      title: '판매중인 데이터 - UFO-Fi',
+      description: 'UFO-Fi 판매중인 데이터를 확인해보세요.',
+    };
+  }
+}
+
+export default function ProfileDataListLayout({ children }: Props) {
+  return <>{children}</>;
+}

--- a/src/app/profile/[userId]/datalist/layout.tsx
+++ b/src/app/profile/[userId]/datalist/layout.tsx
@@ -4,7 +4,7 @@ import { profileAPI } from '@/backend';
 import { IMAGE_PATHS } from '@/constants/images';
 
 interface Props {
-  params: { userId: string };
+  params: Promise<{ userId: string }>;
   children: React.ReactNode;
 }
 
@@ -21,7 +21,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
     const title = `${profile.nickname}님의 판매 데이터`;
     const description = `${profile.nickname}님의 UFO-Fi 판매중인 데이터를 확인해보세요.`;
-    const datalistUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/profile/${params.userId}/datalist`;
+    const datalistUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/profile/${userId}/datalist`;
     const imageUrl = profile.profileImageUrl || IMAGE_PATHS.AVATAR;
 
     return {

--- a/src/shared/ui/Modal/ReportModal.tsx
+++ b/src/shared/ui/Modal/ReportModal.tsx
@@ -24,10 +24,18 @@ type ReportedModalProps = ComponentProps<'div'> & {
   postId?: number;
   isOpen?: boolean;
   onClose?: () => void;
+  onSuccess?: () => void;
 };
 
 export const ReportedModal: React.FC<ReportedModalProps> = (props) => {
-  const { postOwnerUserId = 0, postId = 0, isOpen = false, onClose = () => {}, ...rest } = props;
+  const {
+    postOwnerUserId = 0,
+    postId = 0,
+    isOpen = false,
+    onClose = () => {},
+    onSuccess = () => {},
+    ...rest
+  } = props;
 
   const reportOption = Object.entries(ReportReason).map(([key, label]) => ({
     label,
@@ -74,6 +82,7 @@ export const ReportedModal: React.FC<ReportedModalProps> = (props) => {
             response.statusCode === HttpStatusCode.NO_CONTENT
           ) {
             setCompleteOpen(true);
+            onSuccess?.();
           } else {
             setError(response.message ?? errorMessages.default);
             setFaultOpen(true);
@@ -88,7 +97,7 @@ export const ReportedModal: React.FC<ReportedModalProps> = (props) => {
 
       fetchReport();
     }
-  }, [selectedOption, customReason, postOwnerUserId, postId]);
+  }, [selectedOption, customReason, postOwnerUserId, postId, onSuccess]);
 
   return (
     <div {...rest}>

--- a/src/shared/ui/UserLink/index.tsx
+++ b/src/shared/ui/UserLink/index.tsx
@@ -28,11 +28,10 @@ export function UserLink({
   const href = isValidUser ? `/profile/${numericUserId}` : undefined;
 
   const handleClick = (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-
     // 커스텀 onClick이 있으면 먼저 실행
     if (onClick && event.type === 'click') {
+      event.preventDefault();
+      event.stopPropagation();
       onClick(event as React.MouseEvent<HTMLElement>);
     }
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #528

### 🔎 작업 내용

- [x] 수정되었을 경우 거래소가 Refetch 되도록 수정
- [x] profile/datalist layout 추가
- [x] UserLink -> 프로필 이동하기를 눌러도 이동하지 않던 버그 해결

### 📸 스크린샷 (선택)
![UFO-Fi_UFO-Fi-Chrome2025-08-0501-23-41-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/5f509e00-a8e1-459b-8fcd-858ac156a337)

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 프로필 데이터 리스트 페이지에 SEO 메타데이터가 추가되었습니다.
  * 교환 목록 새로고침 기능이 중앙화되어 삭제 및 신고 처리 후 데이터가 일관되게 갱신됩니다.

* **버그 수정**
  * 교환 목록에서 신고된 게시글이 더 이상 표시되지 않습니다.
  * 사용자 링크 클릭 시 이벤트 동작이 개선되어 불필요한 이벤트 차단이 방지됩니다.

* **개선**
  * 신고 모달에서 신고 성공 시 자동으로 데이터가 갱신됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->