### PR TITLE
UF-424 각종 버그 수정 및 로직 수정

### DIFF
--- a/src/app/mypage/edit-profile/page.tsx
+++ b/src/app/mypage/edit-profile/page.tsx
@@ -29,7 +29,12 @@ export default function EditProfilePage() {
   const [isLoading, setIsLoading] = useState(false);
 
   const handleSaveNickname = async () => {
-    if (await saveNickname()) setModalType('nickname');
+    const result = await saveNickname();
+    if (result === true) {
+      setModalType('nickname');
+    } else {
+      toast.error(result);
+    }
   };
 
   const handleSavePlan = async () => {
@@ -37,7 +42,13 @@ export default function EditProfilePage() {
       toast.error('요금제를 선택해주세요.');
       return;
     }
-    if (await savePlan()) setModalType('plan');
+
+    const result = await savePlan();
+    if (result === true) {
+      setModalType('plan');
+    } else {
+      toast.error(result);
+    }
   };
 
   const handleModalConfirm = () => {

--- a/src/backend/services/profile/profile.ts
+++ b/src/backend/services/profile/profile.ts
@@ -1,5 +1,5 @@
-import { apiRequest } from '@/backend/client/axios';
-import type { GetProfileResponse, ProfileUser } from '@/backend/types/profile';
+import { apiRequest, nextApiRequest } from '@/backend/client/axios';
+import type { GetProfileResponse, ProfileUser, UserStats } from '@/backend/types/profile';
 
 export const profileAPI = {
   async getProfile(anotherUserId: number): Promise<GetProfileResponse> {
@@ -14,5 +14,18 @@ export const profileAPI = {
   async getProfileData(anotherUserId: number): Promise<ProfileUser> {
     const response = await this.getProfile(anotherUserId);
     return response.content;
+  },
+
+  async getUserStats(anotherUserId: number): Promise<{
+    success: boolean;
+    content: UserStats;
+  }> {
+    const response = await nextApiRequest.get<{
+      success: boolean;
+      content: UserStats;
+    }>('/api/collections/user-stats', {
+      params: { userId: anotherUserId },
+    });
+    return response.data;
   },
 };

--- a/src/features/mypage/components/FollowCarousel.tsx
+++ b/src/features/mypage/components/FollowCarousel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -20,6 +21,7 @@ type Neighbor = {
 };
 
 export function FollowCarousel() {
+  const router = useRouter();
   const { isDesktop } = useViewportStore();
   const { data: myInfo } = useMyInfo();
   const isLoggedIn = !!myInfo;
@@ -33,7 +35,7 @@ export function FollowCarousel() {
     const fetchRecommendations = async () => {
       try {
         setLoading(true);
-        // await recommendAPI.updateQdrantCollection();
+        await recommendAPI.updateQdrantCollection();
         const data = await recommendAPI.findRecommendUsers();
         setNeighbors(data ?? []);
 
@@ -103,14 +105,20 @@ export function FollowCarousel() {
             key={n.id}
             className="min-w-[120px] flex flex-col gap-2 justify-between items-center rounded-xl p-3 shadow-md bg-white/10 backdrop-blur-md border border-white/20"
           >
-            <Image
-              src={n.profile}
-              alt={`${n.nickname}-profile`}
-              width={75}
-              height={75}
-              className="rounded-full object-cover border-2 border-white"
-            />
-            <p className="caption-14-bold text-center text-white drop-shadow">{n.nickname}</p>
+            <div
+              className="flex flex-col items-center gap-1 cursor-pointer"
+              onClick={() => router.push(`/profile/${n.id}`)}
+            >
+              <Image
+                src={n.profile}
+                alt={`${n.nickname}-profile`}
+                width={75}
+                height={75}
+                className="rounded-full object-cover border-2 border-white"
+              />
+              <p className="caption-14-bold text-center text-white drop-shadow">{n.nickname}</p>
+            </div>
+
             <Button
               variant={isFollowing ? 'following-button' : 'follow-button'}
               onClick={() => handleFollowToggle(n.id)}

--- a/src/features/profile/components/ProfileView/ProfileContentSections.tsx
+++ b/src/features/profile/components/ProfileView/ProfileContentSections.tsx
@@ -9,7 +9,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/free-mode';
 
-import { nextApiRequest } from '@/backend/client/axios';
+import { profileAPI } from '@/backend';
 import type { ProfileUser, UserStats } from '@/backend/types/profile';
 import { ICON_PATHS } from '@/constants/icons';
 import { Icon } from '@/shared';
@@ -33,26 +33,21 @@ export function ProfileContentSections({ profile }: ProfileContentSectionsProps)
   useEffect(() => {
     const fetchUserStats = async () => {
       try {
-        const response = await nextApiRequest.get<UserStats>('/api/collections/user-stats', {
-          params: { userId: profile.userId },
-        });
-        const { trade_frequency, dominant_trade_time, achievements } = response.data;
+        const data = await profileAPI.getUserStats(profile.userId);
 
-        setUserStats({
-          trade_frequency,
-          dominant_trade_time,
-          achievements,
-        });
-      } catch {
+        if (!data.success || !data.content) {
+          throw new Error('유저 통계 정보를 불러오는 데 실패했습니다.');
+        }
+        setUserStats(data.content);
+      } catch (err) {
+        console.error('[user-stats 에러]', err);
         setUserStats(null);
-        toast.error('유저 통계 정보를 불러오는 데 실패했습니다.');
+        toast.error((err as Error).message);
       }
     };
 
-    if (profile?.userId) {
-      fetchUserStats();
-    }
-  }, [profile?.userId]);
+    fetchUserStats();
+  }, [profile.userId]);
 
   const handleDataListClick = () => {
     router.push(`/profile/${profile.userId}/datalist`);

--- a/src/features/signup/components/OcrInputSection/OcrInputSection.tsx
+++ b/src/features/signup/components/OcrInputSection/OcrInputSection.tsx
@@ -36,12 +36,12 @@ export const OCRInputSection = ({
 }: OCRInputSectionProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const prevCarrier = useRef('');
+  const hasToastedRef = useRef(false); // toast 중복 방지
+
   const [planNameOCR, setPlanNameOCR] = useState('');
   const [carrierOCR, setCarrierOCR] = useState('');
-  const watchedCarrier = useWatch({
-    control,
-    name: 'carrier',
-  });
+  const watchedCarrier = useWatch({ control, name: 'carrier' });
+
   const { mutate: runOCRAndGPT } = useOCRToGptMutation((result) => {
     setPlanNameOCR(result[0]);
     setCarrierOCR(result[1]);
@@ -78,55 +78,65 @@ export const OCRInputSection = ({
   }, [watchedCarrier, setValue, setPlans, setForm, setMaxData, setNetworkType, setIsLoading]);
 
   useEffect(() => {
-    if (carrierOCR) {
-      const matched = VALID_CARRIERS.find(
-        (c) => carrierOCR.toUpperCase().includes(c) || (c === 'LGU' && carrierOCR.includes('LG')),
-      );
-      if (matched) {
-        setValue('carrier', matched as Carrier);
-        setForm({ carrier: matched as Carrier });
-      } else {
-        toast.error('인식된 통신사가 유효하지 않습니다.');
-      }
-    }
+    if (!carrierOCR) return;
 
-    if (planNameOCR) {
+    const matched = VALID_CARRIERS.find(
+      (c) => carrierOCR.toUpperCase().includes(c) || (c === 'LGU' && carrierOCR.includes('LG')),
+    );
+
+    if (matched) {
+      setValue('carrier', matched as Carrier);
+      setForm({ carrier: matched as Carrier });
+    } else if (!hasToastedRef.current) {
+      toast.error('인식된 통신사가 유효하지 않습니다.');
+      hasToastedRef.current = true;
+    }
+  }, [carrierOCR, setValue, setForm]);
+
+  useEffect(() => {
+    if (!planNameOCR || plans.length === 0) return;
+
+    const selected = plans.find((p) => p.planName === planNameOCR);
+
+    if (selected) {
       setValue('planName', planNameOCR, {
         shouldDirty: true,
         shouldTouch: true,
         shouldValidate: true,
       });
-
-      const selected = plans.find((p) => p.planName === planNameOCR);
-
-      if (selected) {
-        setMaxData(selected.sellMobileDataCapacityGB);
-        setNetworkType(selected.mobileDataType.replace(/^_/, ''));
-      } else {
-        setMaxData(null);
-        setNetworkType('');
-        toast.error('요금제를 찾을 수 없습니다. 직접 선택해주세요.');
-      }
+      setForm({ planName: planNameOCR });
+      setMaxData(selected.sellMobileDataCapacityGB);
+      setNetworkType(getMobileDataTypeDisplay(selected.mobileDataType));
+    } else if (!hasToastedRef.current) {
+      toast.error('요금제를 찾을 수 없습니다. 직접 선택해주세요.');
+      setValue('planName', '', {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
+      setForm({ planName: '' });
+      setMaxData(null);
+      setNetworkType('');
+      hasToastedRef.current = true;
     }
-  }, [carrierOCR, planNameOCR, plans, setValue, setForm, setMaxData, setNetworkType]);
+  }, [planNameOCR, plans, setValue, setForm, setMaxData, setNetworkType]);
 
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
     e.target.value = '';
-
     if (!file.type.startsWith('image/')) {
       toast.error('이미지 파일만 업로드 가능합니다.');
       return;
     }
 
-    const maxSize = 10 * 1024 * 1024;
-    if (file.size > maxSize) {
+    if (file.size > 10 * 1024 * 1024) {
       toast.error('파일 크기는 10MB 이하여야 합니다.');
       return;
     }
 
+    hasToastedRef.current = false; // OCR 시작 전 초기화
     const formData = new FormData();
     formData.append('file', file);
     setIsLoading(true);


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #534

### 🔎 작업 내용

- [x] OCR 사용 시, 해당하는 요금제가 없으면 멈추던 버그 수정
- [x] 타 사용자 프로필에서 업적, 주요 시간대, 최근 거래량 등 호출이 되지 않는 현상 수정
- [x] 팔로우 추천에서 임시로 모든 데이터베이스를 Qdrant에 업데이트 하도록 수정

추후, 해당 사용자가 팔로우 추천을 받게되면 그 사용자의 정보만 업데이트 될 수 있도록 개별 적용할 예정

### 📸 스크린샷 (선택)
<img width="617" height="954" alt="image" src="https://github.com/user-attachments/assets/5e7b3958-3c5c-40a6-999c-ada7d7d107af" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 추천 유저의 프로필 이미지 또는 닉네임 클릭 시 해당 유저 프로필 페이지로 이동하는 기능이 추가되었습니다.
  * 프로필 상세에서 사용자 통계 정보를 조회하는 기능이 개선되었습니다.

* **버그 수정**
  * OCR 입력 시 오류 토스트가 중복으로 표시되는 현상이 방지되었습니다.
  * OCR 결과가 유효하지 않을 때 관련 입력값이 올바르게 초기화되고, 오류 메시지가 한 번만 표시됩니다.

* **개선 및 리팩터링**
  * 프로필 편집 시 닉네임 및 요금제 저장 결과에 따라 성공/실패 처리가 더욱 명확하게 동작하도록 개선되었습니다.
  * 프로필 편집 관련 훅의 에러 처리 방식이 상태 기반에서 반환값 기반으로 변경되어, 에러 메시지 관리가 간소화되었습니다.
  * 사용자 통계 조회 로직이 API 모듈을 통해 일관되게 처리되도록 리팩터링되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->