### PR TITLE
UF-426 같은 통신사만 구매 가능하도록 수정

### DIFF
--- a/src/app/exchange/page.tsx
+++ b/src/app/exchange/page.tsx
@@ -5,10 +5,11 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-import { sellAPI, myInfoAPI, purchaseHistory, ExchangePost } from '@/backend';
+import { sellAPI, myInfoAPI, purchaseHistory, ExchangePost, Carrier } from '@/backend';
 import { ExchangeHeader } from '@/features/exchange/components/ExchangeHeader';
 import { ExchangeList } from '@/features/exchange/components/ExchangeList';
 import { Modal, ReportedModal, Title } from '@/shared';
+import { useUserPlan } from '@/shared/hooks/useUserPlan';
 import { queryKeys } from '@/shared/utils';
 import { usePurchaseFlowStore } from '@/stores/usePurchaseFlowStore';
 
@@ -22,6 +23,7 @@ export default function ExchangePage() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isPurchaseLoading, setIsPurchaseLoading] = useState(false);
   const [refetchList, setRefetchList] = useState<() => void>(() => () => {});
+  const { data: userPlan } = useUserPlan();
 
   // 캐시 무효화
   const refetchExchangeData = () => {
@@ -150,6 +152,7 @@ export default function ExchangePage() {
             onPurchase={handlePurchase}
             purchaseLoading={isPurchaseLoading}
             onRefetch={(refetchFunction) => setRefetchList(() => refetchFunction)}
+            myCarrier={userPlan?.carrier as Carrier}
           />
         </section>
       </main>

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import React from 'react';
 
-import { userPlanAPI } from '@/backend';
 import { ICON_PATHS } from '@/constants/icons';
 import { IMAGE_PATHS } from '@/constants/images';
 import { useSellData } from '@/features/hooks/useSellData';
@@ -13,6 +11,7 @@ import { SellCapacitySlider } from '@/features/sell/components/SellCapacitySlide
 import { SellTotalPrice } from '@/features/sell/components/SellTotalPrice';
 import { getSellErrorMessages } from '@/features/sell/utils/sellValidation';
 import { Icon, Input, Title, Button, PriceInput } from '@/shared';
+import { useUserPlan } from '@/shared/hooks/useUserPlan';
 import { useViewportStore } from '@/stores/useViewportStore';
 
 export default function SellPage() {
@@ -33,10 +32,7 @@ export default function SellPage() {
     isSubmitting,
   } = useSellData();
 
-  const { data: userPlan } = useQuery({
-    queryKey: ['userPlan'],
-    queryFn: () => userPlanAPI.get(),
-  });
+  const { data: userPlan } = useUserPlan();
 
   const maxCapacity = myInfo?.sellableDataAmount || 0;
   const isFormValid = isValidTitle && isValidPrice && isValidCapacity;

--- a/src/features/exchange/components/ExchangeList.tsx
+++ b/src/features/exchange/components/ExchangeList.tsx
@@ -22,6 +22,7 @@ interface ExchangeListProps {
   onPurchase: (id: number) => void;
   purchaseLoading?: boolean;
   onRefetch?: (refetchFunction: () => void) => void;
+  myCarrier?: Carrier;
 }
 
 // 게시물 변환 함수
@@ -46,6 +47,7 @@ export const ExchangeList = ({
   onReport,
   onPurchase,
   onRefetch,
+  myCarrier,
 }: ExchangeListProps) => {
   // 사용자 정보 조회
   const { data: userInfo } = useMyInfo();
@@ -120,6 +122,7 @@ export const ExchangeList = ({
                 onDelete={() => onDelete(item.id)}
                 onReport={() => onReport(item.id, item.sellerId)}
                 onPurchase={() => onPurchase(item.id)}
+                myCarrier={myCarrier}
               />
             </div>
           ))}

--- a/src/features/exchange/components/SellingItem.tsx
+++ b/src/features/exchange/components/SellingItem.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 
 import { Carrier } from '@/backend/types/carrier';
@@ -20,6 +22,7 @@ interface SellingItemProps {
   onDelete?: () => void;
   onReport?: () => void;
   onPurchase?: () => void;
+  myCarrier?: Carrier;
 }
 
 const getCarrierIcon = (carrier: string) => {
@@ -52,8 +55,10 @@ export default function SellingItem({
   onDelete,
   onReport,
   onPurchase,
+  myCarrier,
 }: SellingItemProps) {
   const carrierIcon = getCarrierIcon(carrier);
+  const isAbled = carrier !== myCarrier;
 
   return (
     <div className="relative w-full max-w-[170px] sm:max-w-[190px] mb-8">
@@ -124,6 +129,7 @@ export default function SellingItem({
                 size="sm"
                 className="text-xs px-2 py-1"
                 onClick={onPurchase}
+                disabled={isAbled}
               >
                 구매하기
               </Button>

--- a/src/features/profile/components/DataListView/index.tsx
+++ b/src/features/profile/components/DataListView/index.tsx
@@ -8,6 +8,7 @@ import { IMAGE_PATHS } from '@/constants';
 import SellingItem from '@/features/exchange/components/SellingItem';
 import { useProfile } from '@/features/profile/hooks/useProfile';
 import { ReportedModal, Title } from '@/shared';
+import { useUserPlan } from '@/shared/hooks/useUserPlan';
 import { formatPrice, formatTimeAgo, getMobileDataTypeDisplay } from '@/shared/utils';
 
 interface DataListViewProps {
@@ -17,6 +18,7 @@ interface DataListViewProps {
 export function DataListView({ userId }: DataListViewProps) {
   const router = useRouter();
   const { data: profile, isLoading, error } = useProfile(userId);
+  const { data: userPlan } = useUserPlan();
   const [reportModal, setReportModal] = useState({ isOpen: false, postId: 0, sellerId: 0 });
 
   if (isLoading) {
@@ -77,6 +79,7 @@ export function DataListView({ userId }: DataListViewProps) {
                     {...post}
                     onPurchase={() => router.push(`/exchange/purchase/${post.postId}`)}
                     onReport={() => handleReport(post.postId, profile.userId)}
+                    myCarrier={userPlan?.carrier as Carrier}
                   />
                 ))}
             </div>

--- a/src/shared/hooks/useUserPlan.ts
+++ b/src/shared/hooks/useUserPlan.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { userPlanAPI } from '@/backend';
+
+export function useUserPlan() {
+  return useQuery({
+    queryKey: ['userPlan'],
+    queryFn: () => userPlanAPI.get(),
+    staleTime: 1000 * 60 * 5,
+  });
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #536

### 🔎 작업 내용

- [x] 같은 통신사만 구매 가능하도록 수정

### 📸 스크린샷 (선택)
<img width="615" height="948" alt="image" src="https://github.com/user-attachments/assets/2ff27352-0d0a-4ed2-9d75-1c84ba41e419" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 요금제 정보를 가져오는 커스텀 훅이 추가되어, 판매/교환 목록에서 사용자의 통신사 정보를 활용할 수 있게 되었습니다.
  * 판매 아이템의 통신사가 사용자의 통신사와 다를 경우 구매 버튼이 비활성화됩니다.

* **기타 개선**
  * 여러 컴포넌트에서 사용자 통신사 정보를 일관되게 전달하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->