### PR TITLE
UF-428 판매 가능 용량 및 ZET Refetch

### DIFF
--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -146,7 +146,7 @@ export async function POST() {
             id: Number(user.id),
             vector,
             payload: {
-              id: user.id,
+              id: Number(user.id),
               name: user.name ?? 'Unknown',
               role: user.role === 'ROLE_REPORTED' ? 0 : 1,
               type,

--- a/src/app/exchange/purchase/[id]/step1/page.tsx
+++ b/src/app/exchange/purchase/[id]/step1/page.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState, Suspense } from 'react';
 import { IMAGE_PATHS } from '@/constants/images';
 import { InsufficientZetModal } from '@/features/payment/components/InsufficientZetModal';
 import { Button, Loading, Title } from '@/shared';
+import { getMobileDataTypeDisplay } from '@/shared/utils';
 import { analytics } from '@/shared/utils/analytics';
 import { usePurchaseFlowStore } from '@/stores/usePurchaseFlowStore';
 
@@ -112,7 +113,7 @@ function Step1Content() {
           <p className="text-lg mb-2">{productData.title}</p>
           <p className="text-sm text-gray-300 mb-4">
             {productData.sellMobileDataCapacityGb}GB • {productData.carrier} •{' '}
-            {productData.mobileDataType}
+            {getMobileDataTypeDisplay(productData.mobileDataType as '_5G' | 'LTE')}
           </p>
         </div>
 

--- a/src/app/exchange/purchase/[id]/step3/page.tsx
+++ b/src/app/exchange/purchase/[id]/step3/page.tsx
@@ -11,6 +11,7 @@ import { PurchaseErrorRecovery } from '@/features/purchase/components/PurchaseEr
 import { usePurchaseRetry } from '@/features/purchase/hooks/usePurchaseRetry';
 import { Button, Loading, Title } from '@/shared';
 import { analytics } from '@/shared/utils/analytics';
+import queryClient, { queryKeys } from '@/shared/utils/queryClient';
 import { usePurchaseFlowStore } from '@/stores/usePurchaseFlowStore';
 
 function Step3Content() {
@@ -80,6 +81,7 @@ function Step3Content() {
     };
 
     await executePurchase(purchaseRequest);
+    queryClient.invalidateQueries({ queryKey: queryKeys.myInfo() });
   };
 
   const handleErrorRetry = () => {

--- a/src/features/hooks/useSellData.ts
+++ b/src/features/hooks/useSellData.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 
 import { sellAPI } from '@/backend';
 import { validatePricePerGB, validateTotalPrice } from '@/lib/validate';
+import queryClient, { queryKeys } from '@/shared/utils/queryClient';
 
 export const useSellData = () => {
   const [value, setValue] = useState([5]);
@@ -64,6 +65,7 @@ export const useSellData = () => {
     };
 
     await sellMutation.mutateAsync(requestData);
+    queryClient.invalidateQueries({ queryKey: queryKeys.myInfo() });
   };
 
   const handlePriceChange = (e: { target: { value: unknown } }) => {


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #539

### 🔎 작업 내용

- [x] 판매 등록 시 판매 가능 용량 refetch
- [x] 구매 완료 시 ZET refetch

### 📸 스크린샷 (선택)

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Qdrant 업서트 시 payload 내 id 필드가 항상 숫자형으로 변환되어 일관성이 향상되었습니다.

* **개선 사항**
  * 상품 구매 단계에서 모바일 데이터 타입이 사용자에게 더 보기 쉽도록 포맷팅되어 표시됩니다.
  * 구매 완료 및 판매글 등록 후 사용자 정보 캐시가 즉시 갱신되어 최신 정보가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->