### PR TITLE
UF-431 온보딩 페이지로 이동 및 signup 수정

### DIFF
--- a/src/app/signup/plan/layout.tsx
+++ b/src/app/signup/plan/layout.tsx
@@ -8,5 +8,5 @@ export const metadata: Metadata = {
 };
 
 export default function PlanLayout({ children }: { children: ReactNode }) {
-  return <div className="contents">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/signup/plan/page.tsx
+++ b/src/app/signup/plan/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import '@/styles/globals.css';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
-import { getUserInfoResponse, Plan, signupAPI } from '@/backend';
+import { Plan, signupAPI } from '@/backend';
 import { Carrier } from '@/backend/types/carrier';
 import { OCRInputSection, Stepper } from '@/features/signup/components';
 import { signupPlanSchema, SignupPlanSchema } from '@/schemas/signupSchema';
@@ -20,7 +20,7 @@ const PlanPage = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [maxData, setMaxData] = useState<number | null>(null);
   const [networkType, setNetworkType] = useState('');
-  const queryClient = useQueryClient();
+  const router = useRouter();
 
   const {
     control,
@@ -69,17 +69,7 @@ const PlanPage = () => {
       });
       toast.success('회원가입이 완료되었습니다!');
       useSignupStore.getState().reset();
-      queryClient.setQueryData(['userInfo'], (prev: getUserInfoResponse | undefined) => {
-        if (!prev) return prev;
-
-        return {
-          ...prev,
-          content: {
-            ...prev.content,
-            role: 'ROLE_USER',
-          },
-        };
-      });
+      router.push('/onboarding');
     } catch (error) {
       console.error('회원가입 에러:', error);
       toast.error('회원가입 중 오류가 발생했습니다.');
@@ -89,11 +79,9 @@ const PlanPage = () => {
   };
 
   return (
-    <main>
-      <section className="flex flex-col flex-1">
-        <header className="w-full">
-          <Title iconVariant="back" title="회원가입" className="body-20-bold w-full pl-0 mb-6" />
-        </header>
+    <>
+      <section className="flex flex-col w-full min-h-full">
+        <Title iconVariant="back" title="회원가입" className=" body-20-bold w-full pl-0 mb-6" />
 
         <div className="flex flex-col items-start gap-6 w-full">
           <Stepper step={2} content="가입 신청" className="mb-5" />
@@ -150,7 +138,7 @@ const PlanPage = () => {
           {isLoading ? '처리 중...' : '회원가입'}
         </Button>
       </nav>
-    </main>
+    </>
   );
 };
 

--- a/src/app/signup/privacy/layout.tsx
+++ b/src/app/signup/privacy/layout.tsx
@@ -8,5 +8,5 @@ export const metadata: Metadata = {
 };
 
 export default function PrivacyLayout({ children }: { children: ReactNode }) {
-  return <div className="contents">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/signup/privacy/page.tsx
+++ b/src/app/signup/privacy/page.tsx
@@ -17,7 +17,7 @@ const PrivacyPage = () => {
     <>
       <section
         aria-labelledby="privacy-intro-title"
-        className="flex flex-col justify-center items-center text-center gap-7 sm:gap-10 w-full h-full overflow-hidden"
+        className="flex flex-col justify-center items-center text-center gap-7 sm:gap-10 w-full h-full"
       >
         <div className="flex flex-col gap-5 sm:gap-8 pb-5">
           <h2 id="privacy-intro-title" className="body-20-bold">

--- a/src/app/signup/privacy/page.tsx
+++ b/src/app/signup/privacy/page.tsx
@@ -14,14 +14,10 @@ const PrivacyPage = () => {
   };
 
   return (
-    <main>
-      <header className="sr-only">
-        <h1>UFO-Fi 회원가입 시작</h1>
-      </header>
-
+    <>
       <section
         aria-labelledby="privacy-intro-title"
-        className="flex flex-col justify-center items-center text-center gap-7 sm:gap-10 w-full h-full"
+        className="flex flex-col justify-center items-center text-center gap-7 sm:gap-10 w-full h-full overflow-hidden"
       >
         <div className="flex flex-col gap-5 sm:gap-8 pb-5">
           <h2 id="privacy-intro-title" className="body-20-bold">
@@ -44,19 +40,19 @@ const PrivacyPage = () => {
             혜택과 거래 알림도 놓치지 않도록 알려드릴게요!
           </div>
         </div>
-      </section>
 
-      <nav className="w-full mt-10">
-        <Button
-          onClick={handleNext}
-          size="full-width"
-          className="body-16-medium h-10 sm:h-14 text-white"
-          aria-label="회원가입 프로필 입력 화면으로 이동"
-        >
-          다음
-        </Button>
-      </nav>
-    </main>
+        <nav className="w-full mt-10">
+          <Button
+            onClick={handleNext}
+            size="full-width"
+            className="body-16-medium h-10 sm:h-14 text-white"
+            aria-label="회원가입 프로필 입력 화면으로 이동"
+          >
+            다음
+          </Button>
+        </nav>
+      </section>
+    </>
   );
 };
 

--- a/src/app/signup/profile/layout.tsx
+++ b/src/app/signup/profile/layout.tsx
@@ -8,5 +8,5 @@ export const metadata: Metadata = {
 };
 
 export default function ProfileLayout({ children }: { children: ReactNode }) {
-  return <div className="contents">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/signup/profile/page.tsx
+++ b/src/app/signup/profile/page.tsx
@@ -33,12 +33,10 @@ const ProfilePage = () => {
   };
 
   return (
-    <main>
-      <form onSubmit={handleSubmit(onSubmit)} className="flex-1 flex flex-col gap-6">
+    <>
+      <form onSubmit={handleSubmit(onSubmit)} className="w-full min-h-full flex flex-col gap-6">
         <section className="flex-1 flex flex-col justify-start items-start">
-          <header className="w-full">
-            <Title iconVariant="back" title="회원가입" className="body-20-bold pl-0 mb-6" />
-          </header>
+          <Title iconVariant="back" title="회원가입" className="body-20-bold pl-0 mb-6" />
 
           <div className="flex flex-col gap-6 w-full">
             <Stepper step={1} content="정보 입력" className="mb-5" />
@@ -84,7 +82,7 @@ const ProfilePage = () => {
           </Button>
         </nav>
       </form>
-    </main>
+    </>
   );
 };
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -14,7 +14,7 @@ export const ROUTE_CONFIG = {
   ],
 
   // 공개 라우트 (인증 불필요)
-  PUBLIC_ROUTES: ['/login', '/signup'],
+  PUBLIC_ROUTES: ['/login', '/signup', '/onboading'],
 
   // 회원가입 관련 라우트
   SIGNUP_ROUTES: ['/signup/privacy', '/signup/profile', '/signup/plan'],

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -14,7 +14,7 @@ export const ROUTE_CONFIG = {
   ],
 
   // 공개 라우트 (인증 불필요)
-  PUBLIC_ROUTES: ['/login', '/signup', '/onboading'],
+  PUBLIC_ROUTES: ['/login', '/signup', '/onboarding'],
 
   // 회원가입 관련 라우트
   SIGNUP_ROUTES: ['/signup/privacy', '/signup/profile', '/signup/plan'],

--- a/src/features/onboarding/components/NextButton.tsx
+++ b/src/features/onboarding/components/NextButton.tsx
@@ -16,23 +16,26 @@ export const NextButton = ({ isLast, onClick, className = '' }: NextButtonProps)
   const altText = isLast ? '시작하기' : '다음';
   const buttonAnimation = isLast ? '' : 'animate-pulse';
 
-  if (isLast) {
-    queryClient.setQueryData(['userInfo'], (prev: getUserInfoResponse | undefined) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        content: {
-          ...prev.content,
-          role: 'ROLE_USER',
-        },
-      };
-    });
-  }
+  const handleClick = () => {
+    if (isLast) {
+      queryClient.setQueryData(['userInfo'], (prev: getUserInfoResponse | undefined) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          content: {
+            ...prev.content,
+            role: 'ROLE_USER',
+          },
+        };
+      });
+    }
+    onClick();
+  };
 
   return (
     <div className="flex justify-center">
       <button
-        onClick={onClick}
+        onClick={handleClick}
         className={`transition-all duration-300 transform hover:scale-110 active:scale-95 ${buttonAnimation} ${className}`}
         aria-label={altText}
       >

--- a/src/features/onboarding/components/NextButton.tsx
+++ b/src/features/onboarding/components/NextButton.tsx
@@ -1,7 +1,9 @@
 import Image from 'next/image';
 import React from 'react';
 
+import { getUserInfoResponse } from '@/backend';
 import { IMAGE_PATHS } from '@/constants/images';
+import queryClient from '@/shared/utils/queryClient';
 
 interface NextButtonProps {
   isLast: boolean;
@@ -13,6 +15,19 @@ export const NextButton = ({ isLast, onClick, className = '' }: NextButtonProps)
   const imageSrc = isLast ? IMAGE_PATHS.FIRE_BTN_ONBOARDING : IMAGE_PATHS.NEXT_BTN_ONBOARDING;
   const altText = isLast ? '시작하기' : '다음';
   const buttonAnimation = isLast ? '' : 'animate-pulse';
+
+  if (isLast) {
+    queryClient.setQueryData(['userInfo'], (prev: getUserInfoResponse | undefined) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        content: {
+          ...prev.content,
+          role: 'ROLE_USER',
+        },
+      };
+    });
+  }
 
   return (
     <div className="flex justify-center">

--- a/src/provider/AuthProvider.tsx
+++ b/src/provider/AuthProvider.tsx
@@ -55,7 +55,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
 
       // 2. 회원정보 미입력 유저 → 회원가입 절차로 이동
-      if (userRole === 'ROLE_NO_INFO' && !pathname.startsWith('/signup')) {
+      if (
+        userRole === 'ROLE_NO_INFO' &&
+        !pathname.startsWith('/signup') &&
+        !pathname.startsWith('/onboarding')
+      ) {
         // eslint-disable-next-line no-console
         console.log('AuthProvider - ROLE_NO_INFO user, redirecting to signup');
         setHasRedirected(true);


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #541

### 🔎 작업 내용

- [x] Signup 페이지에서 onBoarding page로 이동할 수 있도록 수정
- [x] Signup 페이지 수정

### 📸 스크린샷 (선택)
<img width="765" height="898" alt="image" src="https://github.com/user-attachments/assets/cab8d2f7-8138-4215-bf58-0fd720fa2da7" />
<img width="770" height="907" alt="image" src="https://github.com/user-attachments/assets/b9e49129-fca3-4ec9-8741-283849abf581" />
<img width="766" height="897" alt="image" src="https://github.com/user-attachments/assets/0ba71710-5f2e-468d-aa3a-8e90c46e3af4" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 회원가입 및 프로필, 플랜, 개인정보 입력 화면의 불필요한 레이아웃 래퍼 요소(div, main, header 등)를 제거하여 DOM 구조를 간소화했습니다.
  * 회원가입 완료 시 사용자 정보를 캐시에 반영하는 대신, 성공 후 `/onboarding` 페이지로 이동하도록 변경했습니다.
  * 인증 미완료 사용자의 리다이렉트 조건에 `/onboarding` 경로를 추가하여, 해당 경로 접근 시 불필요한 이동이 발생하지 않도록 개선했습니다.

* **기타**
  * 공개 라우트에 `/onboarding` 경로가 추가되었습니다.
  * 온보딩 마지막 단계에서 사용자 역할 정보를 즉시 캐시에 반영하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->