### PR TITLE
UF-444 메인페이지 하단 행성 - 활성화 된 경우 애니메이션 추가

### DIFF
--- a/src/features/main/components/PlanetProgressBar.tsx
+++ b/src/features/main/components/PlanetProgressBar.tsx
@@ -10,6 +10,7 @@ interface Planet {
   src: string;
   active: boolean;
   color: string;
+  index?: number; // 순차 애니메이션을 위한 index
 }
 
 const getCSSVariable = (name: string): string => {
@@ -60,8 +61,8 @@ export default function PlanetProgressBar() {
 
         {/* 행성들 */}
         <div className="flex gap-3 relative z-10">
-          {planets.map((p) => (
-            <Planet key={p.id} {...p} />
+          {planets.map((p, i) => (
+            <Planet key={p.id} {...p} index={i} />
           ))}
         </div>
         <div className="flex items-center justify-center size-12 rounded-full bg-[#222] text-white text-sm ml-3 relative z-10 flex-shrink-0">
@@ -72,22 +73,60 @@ export default function PlanetProgressBar() {
   );
 }
 
-function Planet({ src, active, color }: Planet) {
+function Planet({ src, active, color, index = 0 }: Planet) {
+  const animationName = `planet-spread-${color.replace(/[^a-zA-Z0-9]/g, '')}`;
+  // 각 행성마다 0.3초씩 딜레이
+  const animationDelay = `${index * 0.3}s`;
   return (
-    <div
-      className="relative size-10 rounded-full flex items-center justify-center"
-      style={{
-        backgroundColor: active ? color : 'transparent',
-        boxShadow: active
-          ? `
-            0 0 0 6px ${hexToRgba(color, 0.6)},
-            0 0 0 12px ${hexToRgba(color, 0.4)},
-            0 0 0 18px ${hexToRgba(color, 0.2)}
-          `
-          : 'none',
-      }}
-    >
-      <Image src={src} alt="planet" width={42} height={42} />
+    <div className="relative size-10 flex items-center justify-center">
+      <div
+        className="absolute inset-0 rounded-full z-0"
+        style={{
+          backgroundColor: active ? color : 'transparent',
+          boxShadow: active
+            ? `0 0 0 6px ${hexToRgba(color, 0.6)}, 0 0 0 12px ${hexToRgba(color, 0.4)}, 0 0 0 18px ${hexToRgba(color, 0.2)}`
+            : 'none',
+          opacity: active ? 1 : 0,
+          animation: active ? `${animationName} 3s linear infinite` : 'none',
+          animationDelay: active ? animationDelay : undefined,
+          transition: 'background-color 0.3s',
+        }}
+      />
+      <span className="relative z-10">
+        <Image src={src} alt="planet" width={42} height={42} />
+      </span>
+      <style jsx>{`
+        @keyframes ${animationName} {
+          0% {
+            box-shadow:
+              0 0 0 6px ${hexToRgba(color, 0.6)},
+              0 0 0 12px ${hexToRgba(color, 0.4)},
+              0 0 0 18px ${hexToRgba(color, 0.2)};
+            opacity: 1;
+          }
+          30% {
+            box-shadow:
+              0 0 0 6px ${hexToRgba(color, 0.4)},
+              0 0 0 12px ${hexToRgba(color, 0.2)},
+              0 0 0 18px ${hexToRgba(color, 0)};
+            opacity: 0.6;
+          }
+          60% {
+            box-shadow:
+              0 0 0 6px ${hexToRgba(color, 0.2)},
+              0 0 0 12px ${hexToRgba(color, 0)},
+              0 0 0 18px ${hexToRgba(color, 0)};
+            opacity: 0.2;
+          }
+          100% {
+            box-shadow:
+              0 0 0 6px ${hexToRgba(color, 0.6)},
+              0 0 0 12px ${hexToRgba(color, 0.4)},
+              0 0 0 18px ${hexToRgba(color, 0.2)};
+            opacity: 1;
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/src/features/main/components/PlanetProgressBar.tsx
+++ b/src/features/main/components/PlanetProgressBar.tsx
@@ -93,7 +93,16 @@ function Planet({ src, active, color, index = 0 }: Planet) {
         }}
       />
       <span className="relative z-10">
-        <Image src={src} alt="planet" width={42} height={42} />
+        <Image
+          src={src}
+          alt="planet"
+          width={42}
+          height={42}
+          style={{
+            filter: active ? 'none' : 'grayscale(1)',
+            transition: 'filter 0.3s, opacity 0.3s',
+          }}
+        />
       </span>
       <style jsx>{`
         @keyframes ${animationName} {


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #552 

### 🔎 작업 내용

- [x] 할 일 1
- [x] 할 일 2

### 📸 스크린샷 (선택)
3개 활성화 (활성화 안 된 행성은 회색처리)
![GIF 2025-08-06 오전 10-57-40](https://github.com/user-attachments/assets/947763e6-b627-4fb3-b7d6-62096a469203)

5개 활성화
![GIF 2025-08-06 오전 10-56-34](https://github.com/user-attachments/assets/fc16986d-ea34-4e34-b84a-958f7c0e51a1)

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 행성 진행 바의 애니메이션 효과가 개선되어, 각 행성 아이콘에 순차적이고 부드러운 글로우(빛나는) 애니메이션이 적용됩니다.
  * 비활성 상태의 행성은 그레이스케일 필터와 함께 자연스러운 전환 효과가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->