### PR TITLE
UF-449 판매등록 페이지 관련 오류 수정

### DIFF
--- a/src/features/sell/components/FixedScaleWrapper.tsx
+++ b/src/features/sell/components/FixedScaleWrapper.tsx
@@ -38,7 +38,7 @@ export const FixedScaleWrapper = ({ children, heightPercent = 1 }: FixedScaleWra
   return (
     <div className="w-full h-full flex justify-center items-center" style={{ overflow: 'hidden' }}>
       {/* 외계인 - 스케일된 영역의 바닥에만 붙음 */}
-      <div className="absolute bottom-0 left-0 z-20">
+      <div className="absolute bottom-0 left-0 z-20 pointer-events-none">
         <Image
           src={IMAGE_PATHS.AL_SELL}
           alt="판매 우주인"

--- a/src/features/sell/components/SellCapacitySlider.tsx
+++ b/src/features/sell/components/SellCapacitySlider.tsx
@@ -17,6 +17,8 @@ export function SellCapacitySlider({
   showTicks = true,
   showLabels = true,
 }: Props) {
+  // value가 [0]이 아니고, value가 0이 들어오면 [0]으로 강제
+  const displayValue = value && value.length === 1 && value[0] === 0 ? [0] : value;
   return (
     <div className="space-y-1 items-center">
       <div className="flex flex-col items-start justify-between">
@@ -37,7 +39,7 @@ export function SellCapacitySlider({
         </div>
       </div>
       <DataSlider
-        value={value}
+        value={displayValue}
         onValueChange={setValue}
         showTicks={showTicks}
         showLabels={showLabels}

--- a/src/features/sell/components/SellFormContent.tsx
+++ b/src/features/sell/components/SellFormContent.tsx
@@ -14,6 +14,22 @@ import { Icon, Input, Button, PriceInput } from '@/shared';
 
 export const SellFormContent = () => {
   const { data: myInfo } = useMyInfo();
+  const maxCapacity = myInfo?.sellableDataAmount || 0;
+
+  // value 초기값을 maxCapacity에 따라 자동 세팅
+  React.useEffect(() => {
+    if (!maxCapacity) return;
+    let initial = 1;
+    if (maxCapacity >= 3) {
+      initial = Math.min(5, Math.floor(maxCapacity / 2));
+    }
+    if (Array.isArray(value)) {
+      if (value[0] !== initial) setValue([initial]);
+    } else {
+      if (value !== initial) setValue([initial]);
+    }
+  }, [maxCapacity]);
+
   const {
     value,
     setValue,
@@ -35,8 +51,19 @@ export const SellFormContent = () => {
     queryFn: () => userPlanAPI.get(),
   });
 
-  const maxCapacity = myInfo?.sellableDataAmount || 0;
   const isFormValid = isValidTitle && isValidPrice && isValidCapacity;
+
+  // value 초기값을 maxCapacity에 따라 자동 세팅
+  React.useEffect(() => {
+    if (!maxCapacity) return;
+    let initial = 1;
+    if (maxCapacity >= 3) {
+      initial = Math.min(5, Math.floor(maxCapacity / 2));
+    }
+    if (Array.isArray(value)) {
+      if (value[0] !== initial) setValue([initial]);
+    }
+  }, [maxCapacity]);
 
   return (
     <div className="flex flex-col w-full h-full justify-between">
@@ -99,13 +126,13 @@ export const SellFormContent = () => {
             isValidPrice={isValidPrice}
           />
         </div>
-        <div className="flex justify-center w-full">
+        <div className="flex justify-center w-full z-50">
           <Button
             size={'sm'}
             onClick={handleSubmit}
             variant="exploration-button"
             disabled={!isFormValid || isSubmitting}
-            className="h-15 ml-auto px-6 py-3"
+            className="h-15 ml-auto px-6 py-3 z-50"
           >
             {isSubmitting ? '등록 중...' : '등록하기'}
           </Button>

--- a/src/features/sell/components/SellFormContent.tsx
+++ b/src/features/sell/components/SellFormContent.tsx
@@ -18,9 +18,10 @@ export const SellFormContent = () => {
 
   // value 초기값을 maxCapacity에 따라 자동 세팅
   React.useEffect(() => {
-    if (!maxCapacity) return;
     let initial = 1;
-    if (maxCapacity >= 3) {
+    if (maxCapacity === 0) {
+      initial = 0;
+    } else if (maxCapacity >= 3) {
       initial = Math.min(5, Math.floor(maxCapacity / 2));
     }
     if (Array.isArray(value)) {
@@ -126,7 +127,7 @@ export const SellFormContent = () => {
             isValidPrice={isValidPrice}
           />
         </div>
-        <div className="flex justify-center w-full z-50">
+        <div className="flex justify-center w-full z-50 relative">
           <Button
             size={'sm'}
             onClick={handleSubmit}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #557 

### 🔎 작업 내용

- [x] 슬라이더 기본값이 현재 전체 용량의 절반값이어도  5GB로뜨던 문제 수정
- [x] 판매 가능 용량이 0기가인 경우 0으로 처리하기 추가
- [x] 등록하기 버튼이 안눌리던 문제 해결

### 📸 스크린샷 (선택)

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 슬라이더 값이 정확히 0일 때 정상적으로 표시되도록 슬라이더 값 처리 방식을 개선했습니다.
  * 판매 용량 선택 시 사용자의 판매 가능 용량에 따라 초기값이 자동으로 설정되도록 개선했습니다.

* **스타일**
  * 하단 왼쪽의 외계인 이미지가 마우스 및 터치 이벤트를 차단하지 않도록 수정했습니다.
  * 제출 버튼과 컨테이너의 z-index 및 레이어링이 개선되어 UI 요소가 올바르게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->