### PR TITLE
UF-455 QA 버그 수정: 루트 /login로 변경 및 회원가입 온보딩 시 네비게이션 비활성화

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,11 +16,6 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 루트 경로는 허용
-  if (pathname === '/') {
-    return NextResponse.next();
-  }
-
   // 공개 라우트 확인
   if (routeUtils.isPublicRoute(pathname) || routeUtils.isSignupRoute(pathname)) {
     return NextResponse.next();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -32,6 +32,12 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
+  // 미인증 시 로그인으로 리다이렉트
+  if (pathname === '/' && !isAuthenticated) {
+    const loginUrl = new URL('/login', request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
   // 인증된 사용자가 블랙홀 라우트 접근 시
   if (routeUtils.isBlackholeRoute(pathname)) {
     return NextResponse.next();

--- a/src/shared/layout/BottomNav/BottomNav.tsx
+++ b/src/shared/layout/BottomNav/BottomNav.tsx
@@ -4,9 +4,11 @@ import Link from 'next/link';
 import React from 'react';
 
 import { cn } from '@/lib/utils';
+import { useAppLayout } from '@/provider/AppLayoutProvider';
 import type { IconType } from '@/shared';
 import { Icon } from '@/shared';
 import { useNavigation } from '@/shared/hooks/useNavigation';
+
 interface NavItem {
   id: string;
   label: string;
@@ -28,8 +30,14 @@ const navItems: NavItem[] = [
 
 const BottomNav: React.FC<BottomNavProps> = ({ onTabChange }) => {
   const { activeTab } = useNavigation();
+  const { isNavigationDisabled } = useAppLayout();
 
-  const handleTabClick = (tab: string) => {
+  const handleTabClick = (tab: string, event: React.MouseEvent) => {
+    if (isNavigationDisabled) {
+      event.preventDefault();
+      return;
+    }
+
     // 외부에서 전달된 onTabChange 콜백이 있으면 먼저 실행
     if (onTabChange && typeof onTabChange === 'function') {
       onTabChange(tab);
@@ -54,15 +62,23 @@ const BottomNav: React.FC<BottomNavProps> = ({ onTabChange }) => {
               >
                 <Link
                   href={item.href}
-                  onClick={() => handleTabClick(item.id)}
+                  onClick={(event) => handleTabClick(item.id, event)}
                   className={cn(
-                    'flex flex-col items-center justify-center gap-1 transition-all duration-200 cursor-pointer no-underline',
+                    'flex flex-col items-center justify-center gap-1 transition-all duration-200 no-underline',
+                    isNavigationDisabled
+                      ? 'pointer-events-none opacity-50 cursor-default'
+                      : 'cursor-pointer',
                     isHome
                       ? 'w-full h-[72px] bg-primary-400 rounded-t-3xl'
                       : 'w-full h-16 hover:bg-white/5 active:scale-95',
                   )}
                   aria-label={item.label}
                   aria-current={isActive ? 'page' : undefined}
+                  // 비활성화된 상태에서는 링크 자체를 비활성화
+                  {...(isNavigationDisabled && {
+                    tabIndex: -1,
+                    'aria-disabled': true,
+                  })}
                 >
                   <Icon
                     name={item.icon}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #568 

### 🔎 작업 내용

- [x] QA 버그 수정
  - [x] 기본 페이지 처음 시작 /login으로 변경
  - [x] 회원가입 시에 USER_NO_INFO일때는 네비게이션이 비활성되도록 함 

### 📸 스크린샷 (선택)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d1085abc-a0fc-47a1-9882-3183251e17c0" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 역할에 따라 내비게이션 UI(상단/하단 바) 전체를 비활성화하는 기능이 추가되었습니다. 특정 역할(ROLE_NO_INFO)일 때 내비게이션이 흐릿하게 표시되고 클릭 및 키보드 접근이 차단됩니다.
  * 인증되지 않은 사용자가 루트 경로("/")에 접근 시 로그인 페이지로 리디렉션됩니다.

* **접근성 개선**
  * 내비게이션이 비활성화된 경우 시각적 표시(투명도, 커서)와 함께 키보드 포커스 및 스크린리더 접근성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->