### PR TITLE
UF-461 어드민 페이지 에러 해결 및 프로필 수정 페이지

### DIFF
--- a/src/app/admin/banned-words/page.tsx
+++ b/src/app/admin/banned-words/page.tsx
@@ -93,11 +93,11 @@ export default function AdminBannedWordsPage() {
   // 페이지네이션 설정
   const pagination: TablePagination = {
     enabled: true,
-    currentPage,
+    currentPage: currentPage + 1,
     totalPages,
     pageSize,
     totalElements,
-    onPageChange: setCurrentPage,
+    onPageChange: (page) => setCurrentPage(page - 1),
     onPageSizeChange: setPageSize,
     pageSizeOptions: [10, 20, 50],
   };

--- a/src/app/login/success/page.tsx
+++ b/src/app/login/success/page.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
 import { getUserInfoAPI } from '@/backend/services/auth/userInfo';
-import { registerFCMToken } from '@/lib/fcm';
 import { Loading } from '@/shared';
 import { useToastStore } from '@/stores/useToastStore';
 import { useUserInfoStore } from '@/stores/useUserInfoStore';
@@ -16,6 +15,7 @@ async function checkAuthCookies(): Promise<{
   isAuthenticated: boolean;
 }> {
   try {
+    // TODO: End Point Constant화
     const response = await fetch('/api/auth/check', {
       method: 'GET',
       credentials: 'include',
@@ -54,11 +54,6 @@ const SuccessPage = () => {
           }, 500);
           return;
         }
-
-        // FCM 토큰 등록 (백그라운드)
-        registerFCMToken().catch((error) => {
-          console.warn('FCM registration failed, but continuing:', error);
-        });
 
         const response = await getUserInfoAPI.getInfo();
 

--- a/src/app/mypage/edit-profile/page.tsx
+++ b/src/app/mypage/edit-profile/page.tsx
@@ -7,7 +7,9 @@ import { toast } from 'sonner';
 import { ConfirmModal, NicknameEditor } from '@/features/mypage/components';
 import { PlanEditor } from '@/features/mypage/components/PlanEditor';
 import { useEditProfile } from '@/features/mypage/hooks/useEditProfile';
+import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
 import { Title } from '@/shared';
+import { useUserPlan } from '@/shared/hooks/useUserPlan';
 
 export default function EditProfilePage() {
   const router = useRouter();
@@ -24,6 +26,9 @@ export default function EditProfilePage() {
     saveNickname,
     savePlan,
   } = useEditProfile();
+
+  const { data: myInfo } = useMyInfo();
+  const { data: userPlan } = useUserPlan();
 
   const [modalType, setModalType] = useState<'nickname' | 'plan' | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -59,6 +64,16 @@ export default function EditProfilePage() {
   return (
     <div>
       <Title title="프로필 수정" iconVariant="back" />
+
+      <div className="mt-4 p-4 bg-gray-50 border rounded-lg text-sm text-gray-700 space-y-1">
+        <div>
+          <span className="font-semibold">현재 닉네임:</span> {myInfo?.nickname ?? '불러오는 중...'}
+        </div>
+        <div>
+          <span className="font-semibold">현재 요금제:</span>{' '}
+          {userPlan?.planName ?? '불러오는 중...'}
+        </div>
+      </div>
 
       <div className="mt-6 flex flex-col gap-8">
         <NicknameEditor

--- a/src/app/mypage/edit-profile/page.tsx
+++ b/src/app/mypage/edit-profile/page.tsx
@@ -6,8 +6,8 @@ import { toast } from 'sonner';
 
 import { ConfirmModal, NicknameEditor } from '@/features/mypage/components';
 import { PlanEditor } from '@/features/mypage/components/PlanEditor';
+import { useMyInfo } from '@/features/mypage/hooks';
 import { useEditProfile } from '@/features/mypage/hooks/useEditProfile';
-import { useMyInfo } from '@/features/mypage/hooks/useMyInfo';
 import { Title } from '@/shared';
 import { useUserPlan } from '@/shared/hooks/useUserPlan';
 
@@ -65,22 +65,13 @@ export default function EditProfilePage() {
     <div>
       <Title title="프로필 수정" iconVariant="back" />
 
-      <div className="mt-4 p-4 bg-gray-50 border rounded-lg text-sm text-gray-700 space-y-1">
-        <div>
-          <span className="font-semibold">현재 닉네임:</span> {myInfo?.nickname ?? '불러오는 중...'}
-        </div>
-        <div>
-          <span className="font-semibold">현재 요금제:</span>{' '}
-          {userPlan?.planName ?? '불러오는 중...'}
-        </div>
-      </div>
-
       <div className="mt-6 flex flex-col gap-8">
         <NicknameEditor
           nickname={nickname}
           setNickname={setNickname}
           onSave={handleSaveNickname}
           isLoading={status === 'loading'}
+          placeholder={myInfo?.nickname}
         />
 
         <PlanEditor
@@ -93,6 +84,10 @@ export default function EditProfilePage() {
           isLoading={isLoading}
           setIsLoading={setIsLoading}
           onSave={handleSavePlan}
+          placeholder={{
+            carrier: userPlan?.carrier ?? '',
+            plan: userPlan?.planName ?? '',
+          }}
         />
       </div>
 

--- a/src/app/signup/plan/page.tsx
+++ b/src/app/signup/plan/page.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { Plan, signupAPI } from '@/backend';
 import { Carrier } from '@/backend/types/carrier';
 import { OCRInputSection, Stepper } from '@/features/signup/components';
+import { registerFCMToken } from '@/lib/fcm';
 import { signupPlanSchema, SignupPlanSchema } from '@/schemas/signupSchema';
 import { Button, Title } from '@/shared';
 import { useSignupStore } from '@/stores/useSignupStore';
@@ -67,6 +68,11 @@ const PlanPage = () => {
           planName: selectedPlan.planName,
         },
       });
+
+      const response = await registerFCMToken();
+
+      if (!response) return;
+
       toast.success('회원가입이 완료되었습니다!');
       useSignupStore.getState().reset();
       router.push('/onboarding');

--- a/src/backend/services/admin/bannedWords.ts
+++ b/src/backend/services/admin/bannedWords.ts
@@ -14,7 +14,7 @@ export const bannedWordsAPI = {
   async getAll(params?: { page?: number; size?: number }): Promise<BannedWordsResponse> {
     const response = await apiRequest.get<BannedWordsResponse>(API_ENDPOINTS.BANNED_WORDS.LIST, {
       params: {
-        page: params?.page || 1,
+        page: params?.page || 0,
         size: params?.size || 10,
       },
     });

--- a/src/backend/services/admin/zetRecovery.ts
+++ b/src/backend/services/admin/zetRecovery.ts
@@ -6,11 +6,15 @@ import type {
   ZetChargeLogResponse,
   ZetChargeLogDetailResponse,
 } from '@/backend/types/zetRecovery';
+import { API_ENDPOINTS } from '@/constants';
 
 export const zetRecoveryAPI = {
   // ZET 복구 처리
   async recoverZet(data: ZetRecoveryRequest): Promise<ZetRecoveryResponse> {
-    const response = await apiRequest.post<ZetRecoveryResponse>('/v1/admin/zet-recovery', data);
+    const response = await apiRequest.post<ZetRecoveryResponse>(
+      API_ENDPOINTS.PAYMENT.RECOVERY,
+      data,
+    );
     return response.data;
   },
 

--- a/src/backend/services/report/report.ts
+++ b/src/backend/services/report/report.ts
@@ -31,7 +31,7 @@ export const reportAPI = {
 
   // 신고된 게시물 목록 조회
   getReportedPosts: async (): Promise<GetReportedPostsResponse> => {
-    const res = await apiRequest.get<GetReportedPostsResponse>(API_ENDPOINTS.REPORT.REPORT_POST(0));
+    const res = await apiRequest.get<GetReportedPostsResponse>(API_ENDPOINTS.REPORT.REPORT_CHECK);
     return res.data;
   },
 

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -73,7 +73,7 @@ export const API_ENDPOINTS = {
 
   // InterestedPost(1)
   INTERESTED_POST: {
-    NOTIFICATION_FILTER: '/v1/notification-filters/interested-post', // 관심 상품 등록 조건 설정
+    NOTIFICATION_FILTER: '/notification-filters/interested-post', // 관심 상품 등록 조건 설정
   },
 
   // Notification(1)

--- a/src/features/admin/hooks/useBannedWords.ts
+++ b/src/features/admin/hooks/useBannedWords.ts
@@ -30,7 +30,7 @@ export function useBannedWords(): UseBannedWordsReturn {
   const [bannedWords, setBannedWords] = useState<BannedWord[]>([]);
   const [totalPages, setTotalPages] = useState(0);
   const [totalElements, setTotalElements] = useState(0);
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -38,18 +38,21 @@ export function useBannedWords(): UseBannedWordsReturn {
 
   // 금칙어 목록 조회
   const fetchBannedWords = useCallback(
-    async (page: number = currentPage, size: number = pageSize) => {
+    async (page?: number, size?: number) => {
+      const effectivePage = page ?? currentPage;
+      const effectiveSize = size ?? pageSize;
+
       try {
         setIsLoading(true);
         setError(null);
 
-        const response = await bannedWordsAPI.getAll({ page, size });
+        const response = await bannedWordsAPI.getAll({ page: effectivePage, size: effectiveSize });
 
         if (response.statusCode === 200) {
           setBannedWords(response.content.content);
           setTotalPages(response.content.totalPages);
           setTotalElements(response.content.totalElements);
-          setCurrentPage(page);
+          setCurrentPage(effectivePage);
         } else {
           throw new Error(response.message || '금칙어 목록을 불러오는데 실패했습니다.');
         }
@@ -73,9 +76,9 @@ export function useBannedWords(): UseBannedWordsReturn {
         additionalActions();
       }
       // 현재 페이지 새로고침
-      await fetchBannedWords(currentPage, pageSize);
+      await fetchBannedWords();
     },
-    [currentPage, pageSize, fetchBannedWords],
+    [fetchBannedWords],
   );
 
   // 금칙어 등록
@@ -190,14 +193,14 @@ export function useBannedWords(): UseBannedWordsReturn {
   const handleSetPageSize = useCallback(
     (size: number) => {
       setPageSize(size);
-      setCurrentPage(1);
-      fetchBannedWords(1, size);
+      setCurrentPage(0);
+      fetchBannedWords(0, size);
     },
     [fetchBannedWords],
   );
 
   useEffect(() => {
-    fetchBannedWords(1, pageSize);
+    fetchBannedWords(0, pageSize);
   }, []); // 의존성 배열을 비워두어 초기 로드만 실행
 
   return {

--- a/src/features/admin/hooks/useBannedWords.ts
+++ b/src/features/admin/hooks/useBannedWords.ts
@@ -184,7 +184,8 @@ export function useBannedWords(): UseBannedWordsReturn {
 
   const handleSetCurrentPage = useCallback(
     (page: number) => {
-      setCurrentPage(page);
+      const adjustedPage = page - 1;
+      setCurrentPage(adjustedPage);
       fetchBannedWords(page, pageSize);
     },
     [pageSize, fetchBannedWords],

--- a/src/features/admin/hooks/useBannedWords.ts
+++ b/src/features/admin/hooks/useBannedWords.ts
@@ -186,7 +186,7 @@ export function useBannedWords(): UseBannedWordsReturn {
     (page: number) => {
       const adjustedPage = page - 1;
       setCurrentPage(adjustedPage);
-      fetchBannedWords(adjustedPage, pageSize);
+      fetchBannedWords(page, pageSize);
     },
     [pageSize, fetchBannedWords],
   );

--- a/src/features/admin/hooks/useBannedWords.ts
+++ b/src/features/admin/hooks/useBannedWords.ts
@@ -186,7 +186,7 @@ export function useBannedWords(): UseBannedWordsReturn {
     (page: number) => {
       const adjustedPage = page - 1;
       setCurrentPage(adjustedPage);
-      fetchBannedWords(page, pageSize);
+      fetchBannedWords(adjustedPage, pageSize);
     },
     [pageSize, fetchBannedWords],
   );

--- a/src/features/mypage/components/NicknameEditor.tsx
+++ b/src/features/mypage/components/NicknameEditor.tsx
@@ -5,9 +5,16 @@ interface NicknameEditorProps {
   setNickname: (nickname: string) => void;
   onSave: () => void;
   isLoading: boolean;
+  placeholder?: string;
 }
 
-export function NicknameEditor({ nickname, setNickname, onSave, isLoading }: NicknameEditorProps) {
+export function NicknameEditor({
+  nickname,
+  setNickname,
+  onSave,
+  isLoading,
+  placeholder,
+}: NicknameEditorProps) {
   const isValid = nickname.length > 0 && nickname.length <= 15;
 
   return (
@@ -16,7 +23,7 @@ export function NicknameEditor({ nickname, setNickname, onSave, isLoading }: Nic
       <Input
         value={nickname}
         onChange={(e) => setNickname(e.target.value)}
-        placeholder="변경할 닉네임을 입력해주세요."
+        placeholder={placeholder || '변경할 닉네임을 입력해주세요.'}
         variant="whiteBorder"
         maxLength={15}
         error={!isValid && nickname ? '닉네임은 1~15자 이내여야 합니다.' : undefined}

--- a/src/features/mypage/components/PlanEditor.tsx
+++ b/src/features/mypage/components/PlanEditor.tsx
@@ -56,7 +56,6 @@ export function PlanEditor({
   // placeholder를 폼 필드에 반영 (초기 렌더 이후)
   useEffect(() => {
     if (placeholder?.carrier) setValue('carrier', placeholder.carrier);
-    if (placeholder?.plan) setValue('planName', placeholder.plan);
   }, [placeholder, setValue]);
 
   return (

--- a/src/features/mypage/components/PlanEditor.tsx
+++ b/src/features/mypage/components/PlanEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { Plan } from '@/backend';
@@ -20,6 +20,10 @@ interface PlanEditorProps {
   isLoading: boolean;
   setIsLoading: (value: boolean) => void;
   onSave: () => void;
+  placeholder?: {
+    carrier?: string;
+    plan?: string;
+  };
 }
 
 export function PlanEditor({
@@ -32,6 +36,7 @@ export function PlanEditor({
   isLoading,
   setIsLoading,
   onSave,
+  placeholder,
 }: PlanEditorProps) {
   const [maxData, setMaxData] = useState<number | null>(null);
   const [networkType, setNetworkType] = useState('');
@@ -43,14 +48,21 @@ export function PlanEditor({
   } = useForm<SignupPlanSchema>({
     resolver: zodResolver(signupPlanSchema),
     defaultValues: {
-      carrier: carrier || '',
-      planName: plan || '',
+      carrier: carrier || placeholder?.carrier || '',
+      planName: plan || placeholder?.plan || '',
     },
   });
+
+  // placeholder를 폼 필드에 반영 (초기 렌더 이후)
+  useEffect(() => {
+    if (placeholder?.carrier) setValue('carrier', placeholder.carrier);
+    if (placeholder?.plan) setValue('planName', placeholder.plan);
+  }, [placeholder, setValue]);
 
   return (
     <div>
       <h2 className="mb-4 font-semibold text-lg">요금제 변경</h2>
+
       <OCRInputSection
         control={control}
         errors={errors}
@@ -65,7 +77,12 @@ export function PlanEditor({
           if (carrier) setCarrier(carrier);
           if (planName) setPlan(planName);
         }}
+        placeholder={{
+          carrier: placeholder?.carrier ?? '',
+          planName: placeholder?.plan ?? '',
+        }}
       />
+
       {carrier && plan && maxData !== null && networkType && (
         <div className="w-full flex flex-col gap-5 mt-8">
           <hr className="border-t border-[var(--color-hr-border)] w-full" />
@@ -86,6 +103,7 @@ export function PlanEditor({
           </div>
         </div>
       )}
+
       <Button
         className="w-full h-12 mt-4"
         disabled={!carrier || !plan || isLoading}

--- a/src/features/signup/components/OcrInputSection/OcrInputSection.tsx
+++ b/src/features/signup/components/OcrInputSection/OcrInputSection.tsx
@@ -33,6 +33,7 @@ export const OCRInputSection = ({
   isLoading,
   setIsLoading,
   setForm,
+  placeholder,
 }: OCRInputSectionProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const prevCarrier = useRef('');
@@ -209,6 +210,7 @@ export const OCRInputSection = ({
                 }
               }}
               disabled={isLoading}
+              placeholder={placeholder?.planName}
             />
           )}
         />

--- a/src/features/signup/components/OcrInputSection/OcrInputSection.types.ts
+++ b/src/features/signup/components/OcrInputSection/OcrInputSection.types.ts
@@ -16,4 +16,8 @@ export interface OCRInputSectionProps {
   isLoading: boolean;
   setIsLoading: (b: boolean) => void;
   setForm: (form: { carrier?: Carrier; planName?: string }) => void;
+  placeholder?: {
+    carrier?: string;
+    planName?: string;
+  };
 }

--- a/src/features/signup/components/PlanCombo/PlanCombo.tsx
+++ b/src/features/signup/components/PlanCombo/PlanCombo.tsx
@@ -15,7 +15,13 @@ import {
 import type { PlanComboProps } from './PlanCombo.types';
 import { planComboItemClass } from './planComboVariants';
 
-export function PlanCombo({ planNames = [], onSelect, value, disabled = false }: PlanComboProps) {
+export function PlanCombo({
+  planNames = [],
+  onSelect,
+  value,
+  disabled = false,
+  placeholder,
+}: PlanComboProps) {
   const [input, setInput] = useState('');
   const [isOpen, setIsOpen] = useState(false);
 
@@ -33,7 +39,7 @@ export function PlanCombo({ planNames = [], onSelect, value, disabled = false }:
     <div className="relative w-full">
       <Command className="w-full">
         <CommandInput
-          placeholder="요금제를 선택해 주세요."
+          placeholder={placeholder || '요금제를 선택해 주세요.'}
           value={input}
           onFocus={() => !disabled && setIsOpen(true)}
           onBlur={() => setTimeout(() => setIsOpen(false), 100)}

--- a/src/features/signup/components/PlanCombo/PlanCombo.types.ts
+++ b/src/features/signup/components/PlanCombo/PlanCombo.types.ts
@@ -3,4 +3,5 @@ export interface PlanComboProps {
   onSelect?: (value: string) => void;
   value: string;
   disabled: boolean;
+  placeholder?: string;
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #575

### 🔎 작업 내용

- [x] 어드민 페이지 에러 해결
- [x] 회원 정보 변경 페이지에 현재 닉네임 및 요금제 임시 표시

### 📸 스크린샷 (선택)
<img width="620" height="778" alt="image" src="https://github.com/user-attachments/assets/4974267c-da08-4c7e-ae5e-2927fc8ce018" />

### 📢 전달사항
planCombo의 placeholer에 입력한 값이 input에도 들어감
<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **버그 수정**
  * 금지어 관리 페이지의 페이지네이션 인덱스가 0부터 시작하도록 수정되어, UI와 내부 상태의 일관성이 개선되었습니다.
  * 금지어 관련 데이터 조회 및 페이지 이동 시 0 기반 인덱싱이 적용되었습니다.

* **기능 개선**
  * 회원가입 완료 시 FCM 토큰 등록 절차가 추가되어 알림 기능 연동이 강화되었습니다.
  * 프로필 수정 페이지에 현재 닉네임과 플랜 정보를 읽기 전용으로 표시하는 정보 섹션이 추가되었습니다.
  * 닉네임 및 요금제 입력 필드에 기존 사용자 정보 기반의 플레이스홀더가 표시되도록 개선되었습니다.

* **기타**
  * 일부 API 엔드포인트 경로가 변경되어 내부 호출이 개선되었습니다.
  * 사용되지 않는 FCM 토큰 등록 코드가 로그인 성공 페이지에서 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->