### PR TITLE
UF-465 admin payments API 연동 및 전파거리 탭 URL 수정

### DIFF
--- a/src/app/admin/zet-charge-logs/page.tsx
+++ b/src/app/admin/zet-charge-logs/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 
+import { zetRecoveryAPI } from '@/backend';
 import {
   Button,
   Header,
@@ -19,122 +20,10 @@ interface ChargeLogTableRow extends BaseTableRow {
   orderId: string;
   userId: number;
   userName: string;
-  amount: number;
-  status: 'PENDING' | 'COMPLETED' | 'FAILED' | 'CANCELLED';
-  createdAt: string;
+  price: number;
+  paymentStatus: 'DONE' | 'FAIL' | 'IN_PROGRESS' | 'READY' | 'TIMEOUT';
+  requestedAt: string;
 }
-
-// TODO: 더미데이터
-const DUMMY_CHARGE_LOGS: ChargeLogTableRow[] = [
-  {
-    id: 1,
-    orderId: 'ORDER_2025080401',
-    userId: 1001,
-    userName: '정지호',
-    amount: 50000,
-    status: 'COMPLETED',
-    createdAt: '2025-08-04T10:30:00Z',
-  },
-  {
-    id: 2,
-    orderId: 'ORDER_2025080402',
-    userId: 1002,
-    userName: '송현규',
-    amount: 30000,
-    status: 'COMPLETED',
-    createdAt: '2025-08-04T11:15:00Z',
-  },
-  {
-    id: 3,
-    orderId: 'ORDER_2025080403',
-    userId: 1003,
-    userName: '정민경',
-    amount: 100000,
-    status: 'FAILED',
-    createdAt: '2025-08-04T12:00:00Z',
-  },
-];
-
-// 더미 로그 상세 데이터
-const DUMMY_LOG_DETAILS = {
-  1: {
-    title: 'ZET 충전 성공 - ORDER_2025080401',
-    request: {
-      orderId: 'ORDER_2025080401',
-      userId: 1001,
-      amount: 50000,
-      paymentMethod: 'CARD',
-      timestamp: '2025-08-04T10:30:00Z',
-    },
-    tossResponse: {
-      paymentKey: 'tgen_20250804103001_ABC123',
-      orderId: 'ORDER_2025080401',
-      status: 'DONE',
-      totalAmount: 50000,
-      method: '카드',
-      approvedAt: '2025-08-04T10:30:15Z',
-    },
-    statusTransition: [
-      { status: 'PENDING', timestamp: '2025-08-04T10:30:00Z', description: '결제 요청' },
-      { status: 'PROCESSING', timestamp: '2025-08-04T10:30:10Z', description: '토스 결제 처리중' },
-      {
-        status: 'COMPLETED',
-        timestamp: '2025-08-04T10:30:15Z',
-        description: '결제 완료 및 ZET 지급',
-      },
-    ],
-  },
-  2: {
-    title: 'ZET 충전 성공 - ORDER_2025080402',
-    request: {
-      orderId: 'ORDER_2025080402',
-      userId: 1002,
-      amount: 30000,
-      paymentMethod: 'CARD',
-      timestamp: '2025-08-04T11:15:00Z',
-    },
-    tossResponse: {
-      paymentKey: 'tgen_20250804111501_DEF456',
-      orderId: 'ORDER_2025080402',
-      status: 'DONE',
-      totalAmount: 30000,
-      method: '카드',
-      approvedAt: '2025-08-04T11:15:20Z',
-    },
-    statusTransition: [
-      { status: 'PENDING', timestamp: '2025-08-04T11:15:00Z', description: '결제 요청' },
-      { status: 'PROCESSING', timestamp: '2025-08-04T11:15:12Z', description: '토스 결제 처리중' },
-      {
-        status: 'COMPLETED',
-        timestamp: '2025-08-04T11:15:20Z',
-        description: '결제 완료 및 ZET 지급',
-      },
-    ],
-  },
-  3: {
-    title: 'ZET 충전 실패 - ORDER_2025080403',
-    request: {
-      orderId: 'ORDER_2025080403',
-      userId: 1003,
-      paymentMethod: 'CARD',
-      timestamp: '2025-08-04T12:00:00Z',
-    },
-    tossResponse: {
-      paymentKey: null,
-      orderId: 'ORDER_2025080403',
-      status: 'FAILED',
-      totalAmount: 100000,
-      method: '카드',
-      failReason: '한도 초과',
-      failedAt: '2025-08-04T12:00:25Z',
-    },
-    statusTransition: [
-      { status: 'PENDING', timestamp: '2025-08-04T12:00:00Z', description: '결제 요청' },
-      { status: 'PROCESSING', timestamp: '2025-08-04T12:00:15Z', description: '토스 결제 처리중' },
-      { status: 'FAILED', timestamp: '2025-08-04T12:00:25Z', description: '결제 실패 - 한도 초과' },
-    ],
-  },
-};
 
 export default function AdminZetChargeLogsPage() {
   const [chargeLogs, setChargeLogs] = useState<ChargeLogTableRow[]>([]);
@@ -146,17 +35,35 @@ export default function AdminZetChargeLogsPage() {
 
   const { openModal } = useModal();
 
-  // 더미 데이터 로드
   useEffect(() => {
-    setIsLoading(true);
-    setCurrentPage(0);
-    setTimeout(() => {
-      setChargeLogs(DUMMY_CHARGE_LOGS);
-      setTotalElements(DUMMY_CHARGE_LOGS.length);
-      setTotalPages(Math.ceil(DUMMY_CHARGE_LOGS.length / pageSize));
-      setIsLoading(false);
-    }, 500);
-  }, [pageSize]);
+    const fetchLogs = async () => {
+      setIsLoading(true);
+      try {
+        const response = await zetRecoveryAPI.getChargeLogs();
+        const logs = response?.content?.paymentBackOfficesRes ?? [];
+
+        const content: ChargeLogTableRow[] = logs.map((log) => ({
+          id: log.id,
+          orderId: log.orderId,
+          userId: log.userId,
+          userName: log.username || '-',
+          price: log.price,
+          paymentStatus: log.paymentStatus,
+          requestedAt: log.requestedAt,
+        }));
+
+        setChargeLogs(content);
+        setTotalPages(1);
+        setTotalElements(logs.length);
+      } catch (error) {
+        console.error('ZET 충전 로그 조회 실패:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchLogs();
+  }, [currentPage, pageSize]);
 
   const columns: TableColumn<ChargeLogTableRow>[] = [
     {
@@ -184,7 +91,7 @@ export default function AdminZetChargeLogsPage() {
     },
     {
       Header: '충전금액',
-      accessor: 'amount',
+      accessor: 'price',
       width: '120px',
       render: (value: unknown) => (
         <span className="font-semibold text-blue-600">{Number(value).toLocaleString()}원</span>
@@ -192,26 +99,30 @@ export default function AdminZetChargeLogsPage() {
     },
     {
       Header: '상태',
-      accessor: 'status',
+      accessor: 'paymentStatus',
       width: '100px',
       render: (value: unknown) => {
         const status = String(value);
         const statusColors = {
-          COMPLETED: 'bg-green-100 text-green-800',
-          PENDING: 'bg-yellow-100 text-yellow-800',
-          FAILED: 'bg-red-100 text-red-800',
-          CANCELLED: 'bg-gray-100 text-gray-800',
+          DONE: 'bg-green-100 text-green-800',
+          IN_PROGRESS: 'bg-yellow-100 text-yellow-800',
+          FAIL: 'bg-red-100 text-red-800',
+          TIMEOUT: 'bg-gray-100 text-gray-800',
+          READY: 'bg-gray-100 text-gray-800',
         };
         const statusLabels = {
-          COMPLETED: '완료',
-          PENDING: '대기',
-          FAILED: '실패',
-          CANCELLED: '취소',
+          DONE: '완료',
+          IN_PROGRESS: '진행중',
+          FAIL: '실패',
+          TIMEOUT: '시간초과',
+          READY: '대기중',
         };
 
         return (
           <span
-            className={`px-2 py-1 rounded-full text-xs font-medium ${statusColors[status as keyof typeof statusColors]}`}
+            className={`px-2 py-1 rounded-full text-xs font-medium ${
+              statusColors[status as keyof typeof statusColors] || ''
+            }`}
           >
             {statusLabels[status as keyof typeof statusLabels] || status}
           </span>
@@ -220,7 +131,7 @@ export default function AdminZetChargeLogsPage() {
     },
     {
       Header: '발행시각',
-      accessor: 'createdAt',
+      accessor: 'requestedAt',
       width: '140px',
       mobileHidden: true,
       render: (value: unknown) => new Date(String(value)).toLocaleString('ko-KR'),
@@ -250,91 +161,70 @@ export default function AdminZetChargeLogsPage() {
   };
 
   function handleViewDetails(row: ChargeLogTableRow) {
-    const logDetail = DUMMY_LOG_DETAILS[row.id as keyof typeof DUMMY_LOG_DETAILS];
+    setIsLoading(true);
 
-    if (!logDetail) {
-      return;
-    }
+    zetRecoveryAPI
+      .getChargeLogDetail(row.id)
+      .then((res) => {
+        const { orderId, confirmReq, confirmResult, methodTrace } = res.content;
 
-    openModal('chargeLogDetails', {
-      title: logDetail.title,
-      size: 'lg',
-      type: 'single',
-      headerAlign: 'left',
-      hasCloseButton: true,
-      primaryButtonText: '확인',
-      children: (
-        <div className="space-y-6 max-h-10 max-w-md overflow-y-auto">
-          {/* 요청 정보 */}
-          <div>
-            <h4 className="text-lg font-semibold text-gray-900 mb-3">요청 정보</h4>
-            <div className="bg-gray-50 rounded-lg p-4">
-              <pre className="text-sm text-gray-800 whitespace-pre-wrap">
-                {JSON.stringify(logDetail.request, null, 2)}
-              </pre>
-            </div>
-          </div>
-
-          {/* 토스 응답 */}
-          <div>
-            <h4 className="text-lg font-semibold text-gray-900 mb-3">토스 응답</h4>
-            <div className="bg-gray-50 rounded-lg p-4">
-              <pre className="text-sm text-gray-800 whitespace-pre-wrap">
-                {JSON.stringify(logDetail.tossResponse, null, 2)}
-              </pre>
-            </div>
-          </div>
-
-          {/* 상태 전이 */}
-          <div>
-            <h4 className="text-lg font-semibold text-gray-900 mb-3">상태 전이</h4>
-            <div className="space-y-3">
-              {logDetail.statusTransition.map((transition, index) => (
-                <div key={index} className="flex items-start space-x-3">
-                  <div className="flex-shrink-0">
-                    <div
-                      className={`w-3 h-3 rounded-full ${
-                        transition.status === 'COMPLETED'
-                          ? 'bg-green-500'
-                          : transition.status === 'FAILED'
-                            ? 'bg-red-500'
-                            : transition.status === 'PROCESSING'
-                              ? 'bg-yellow-500'
-                              : 'bg-gray-400'
-                      }`}
-                    />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center space-x-2">
-                      <span className="text-sm font-semibold text-gray-900">
-                        {transition.status}
-                      </span>
-                      <span className="text-xs text-gray-500">
-                        {new Date(transition.timestamp).toLocaleString('ko-KR')}
-                      </span>
-                    </div>
-                    <p className="text-sm text-gray-600 mt-1">{transition.description}</p>
-                  </div>
+        openModal('chargeLogDetails', {
+          title: `ZET 충전 로그 상세 - ${orderId}`,
+          size: 'lg',
+          type: 'single',
+          headerAlign: 'left',
+          hasCloseButton: true,
+          primaryButtonText: '확인',
+          children: (
+            <div className="max-h-[70vh] overflow-y-auto pr-2 space-y-6">
+              <div className="space-y-4 text-sm text-gray-800">
+                <div>
+                  <h4 className="text-gray-600 font-semibold">주문번호</h4>
+                  <p className="mt-1">{orderId}</p>
                 </div>
-              ))}
+
+                <div>
+                  <h4 className="text-gray-600 font-semibold">요청 데이터 (confirmReq)</h4>
+                  <pre className="bg-white border border-gray-200 rounded p-3 whitespace-pre-wrap overflow-x-auto max-h-64">
+                    {confirmReq}
+                  </pre>
+                </div>
+
+                <div>
+                  <h4 className="text-gray-600 font-semibold">응답 데이터 (confirmResult)</h4>
+                  <pre className="bg-white border border-gray-200 rounded p-3 whitespace-pre-wrap overflow-x-auto max-h-64">
+                    {confirmResult}
+                  </pre>
+                </div>
+
+                <div>
+                  <h4 className="text-gray-600 font-semibold">메서드 트레이스</h4>
+                  <pre className="bg-white border border-gray-200 rounded p-3 whitespace-pre-wrap overflow-x-auto max-h-64">
+                    {methodTrace}
+                  </pre>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      ),
-    });
+          ),
+        });
+      })
+      .catch((err) => {
+        console.error('충전 로그 상세 조회 실패:', err);
+        openModal('alert', {
+          title: '오류',
+          description: '상세 로그를 불러오는 데 실패했습니다.',
+          primaryButtonText: '확인',
+        });
+      })
+      .finally(() => setIsLoading(false));
   }
 
   const handleRefresh = () => {
-    setIsLoading(true);
-    setTimeout(() => {
-      setChargeLogs([...DUMMY_CHARGE_LOGS]);
-      setIsLoading(false);
-    }, 500);
+    setCurrentPage(0);
   };
 
   return (
     <div className="flex h-screen bg-gray-50">
-      {/* 사이드바 - 데스크톱에서만 표시 */}
       <div className="hidden lg:block">
         <Sidebar />
       </div>
@@ -342,7 +232,6 @@ export default function AdminZetChargeLogsPage() {
         <Header userName="Admin" />
         <main className="flex-1 overflow-y-auto p-4 lg:p-8">
           <div className="max-w-7xl mx-auto">
-            {/* 페이지 헤더 */}
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-4">
               <h1 className="text-2xl font-bold text-gray-900">ZET 충전 내역 로그</h1>
               <div className="flex gap-2">
@@ -357,7 +246,6 @@ export default function AdminZetChargeLogsPage() {
               </div>
             </div>
 
-            {/* 통계 카드 */}
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
               <div className="bg-white rounded-lg shadow p-6">
                 <h3 className="text-sm font-medium text-gray-500 mb-2">전체 충전</h3>
@@ -366,28 +254,27 @@ export default function AdminZetChargeLogsPage() {
               <div className="bg-white rounded-lg shadow p-6">
                 <h3 className="text-sm font-medium text-gray-500 mb-2">성공</h3>
                 <p className="text-2xl font-bold text-green-600">
-                  {chargeLogs.filter((log) => log.status === 'COMPLETED').length}
+                  {chargeLogs.filter((log) => log.paymentStatus === 'DONE').length}
                 </p>
               </div>
               <div className="bg-white rounded-lg shadow p-6">
                 <h3 className="text-sm font-medium text-gray-500 mb-2">실패</h3>
                 <p className="text-2xl font-bold text-red-600">
-                  {chargeLogs.filter((log) => log.status === 'FAILED').length}
+                  {chargeLogs.filter((log) => log.paymentStatus === 'FAIL').length}
                 </p>
               </div>
               <div className="bg-white rounded-lg shadow p-6">
                 <h3 className="text-sm font-medium text-gray-500 mb-2">총 충전액</h3>
                 <p className="text-2xl font-bold text-purple-600">
                   {chargeLogs
-                    .filter((log) => log.status === 'COMPLETED')
-                    .reduce((sum, log) => sum + log.amount, 0)
+                    .filter((log) => log.paymentStatus === 'DONE')
+                    .reduce((sum, log) => sum + log.price, 0)
                     .toLocaleString()}
                   원
                 </p>
               </div>
             </div>
 
-            {/* 충전 내역 로그 테이블 */}
             <AdminTable
               title="충전 내역 로그"
               description="사용자들의 ZET 충전 내역과 결제 로그를 확인할 수 있습니다."

--- a/src/app/signal/page.tsx
+++ b/src/app/signal/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { useState, useEffect } from 'react';
 
 import { LetterTabContent } from '@/features/signal/components/LetterTabContent';
 import SignalTabContent from '@/features/signal/components/SignalTabContent';
@@ -10,7 +11,12 @@ import { TutorialOverlay } from '@/shared/components/TutorialOverlay';
 type TabType = 'orbit' | 'letters';
 
 export default function SignalPage() {
-  const [activeTab, setActiveTab] = useState<TabType>('orbit');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const initialTab = (searchParams.get('tab') as TabType) || 'orbit';
+  const [activeTab, setActiveTab] = useState<TabType>(initialTab);
   const [showTutorial, setShowTutorial] = useState(false);
   const [step, setStep] = useState(0);
   const [isOrbitLoaded, setIsOrbitLoaded] = useState(false);
@@ -21,6 +27,12 @@ export default function SignalPage() {
       setShowTutorial(true);
     }
   }, [isOrbitLoaded]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams);
+    params.set('tab', activeTab);
+    router.replace(`${pathname}?${params.toString()}`);
+  }, [activeTab, pathname, router, searchParams]);
 
   const handleNext = () => {
     if (step === 0) {

--- a/src/backend/services/admin/zetRecovery.ts
+++ b/src/backend/services/admin/zetRecovery.ts
@@ -2,7 +2,6 @@ import { apiRequest } from '@/backend/client/axios';
 import type {
   ZetRecoveryRequest,
   ZetRecoveryResponse,
-  ZetChargeLogRequest,
   ZetChargeLogResponse,
   ZetChargeLogDetailResponse,
 } from '@/backend/types/zetRecovery';
@@ -19,24 +18,15 @@ export const zetRecoveryAPI = {
   },
 
   // ZET 충전 내역 로그 조회 (페이지네이션)
-  async getChargeLogs(params?: ZetChargeLogRequest): Promise<ZetChargeLogResponse> {
-    const response = await apiRequest.get<ZetChargeLogResponse>('/v1/admin/zet-charge-logs', {
-      params: {
-        page: params?.page || 0,
-        size: params?.size || 10,
-        startDate: params?.startDate,
-        endDate: params?.endDate,
-        status: params?.status,
-        userId: params?.userId,
-      },
-    });
+  async getChargeLogs(): Promise<ZetChargeLogResponse> {
+    const response = await apiRequest.get<ZetChargeLogResponse>(API_ENDPOINTS.PAYMENT.PAYMENT);
     return response.data;
   },
 
   // ZET 충전 로그 상세 조회
-  async getChargeLogDetail(logId: number): Promise<ZetChargeLogDetailResponse> {
+  async getChargeLogDetail(paymentId: number): Promise<ZetChargeLogDetailResponse> {
     const response = await apiRequest.get<ZetChargeLogDetailResponse>(
-      `/v1/admin/zet-charge-logs/${logId}`,
+      API_ENDPOINTS.PAYMENT.PAYMENT_DETAIL(paymentId),
     );
     return response.data;
   },

--- a/src/backend/types/zetRecovery.ts
+++ b/src/backend/types/zetRecovery.ts
@@ -21,39 +21,23 @@ export interface ZetRecoveryContent {
 export type ZetRecoveryResponse = SuccessApiResponse<ZetRecoveryContent>;
 
 // ZET 충전 로그 관련 타입들
-export interface ZetChargeLogRequest {
-  page?: number;
-  size?: number;
-  startDate?: string;
-  endDate?: string;
-  status?: 'PENDING' | 'COMPLETED' | 'FAILED' | 'CANCELLED';
-  userId?: number;
-}
-
 export interface ZetChargeLogItem {
   id: number;
   orderId: string;
   userId: number;
-  userName: string;
-  amount: number;
-  zetAmount: number;
-  status: 'PENDING' | 'COMPLETED' | 'FAILED' | 'CANCELLED';
-  paymentMethod: string;
-  createdAt: string;
-  completedAt?: string;
-  failReason?: string;
-  tossPaymentKey?: string;
+  username: string;
+  price: number;
+  paymentStatus: 'DONE' | 'FAIL' | 'IN_PROGRESS' | 'READY' | 'TIMEOUT';
+  requestedAt: string;
 }
 
 // 로그 상세 조회용 타입
 export interface ZetPaymentRequestLog {
   orderId: string;
   userId: number;
-  amount: number;
-  paymentMethod: string;
-  timestamp: string;
-  // customerName?: string;
-  // customerEmail?: string;
+  confirmReq: string;
+  confirmResult: string;
+  methodTrace: string;
 }
 
 export interface ZetTossPaymentResponseLog {
@@ -76,23 +60,18 @@ export interface ZetStatusTransition {
 }
 
 export interface ZetChargeLogDetail {
-  id: number;
-  title: string;
-  request: ZetPaymentRequestLog;
-  tossResponse: ZetTossPaymentResponseLog;
-  statusTransition: ZetStatusTransition[];
+  orderId: string;
+  confirmReq: string;
+  confirmResult: string;
+  methodTrace: string;
 }
 
 export interface ZetChargeLogContent {
-  content: ZetChargeLogItem[];
-  totalElements: number;
-  totalPages: number;
-  size: number;
-  number: number;
-  numberOfElements: number;
-  first: boolean;
-  last: boolean;
-  empty: boolean;
+  paymentBackOfficesRes: ZetChargeLogItem[];
+}
+
+export interface ZetChargeLogResponseContent {
+  paymentBackOfficesRes: ZetChargeLogItem[];
 }
 
 export type ZetChargeLogResponse = SuccessApiResponse<ZetChargeLogContent>;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -106,6 +106,8 @@ export const API_ENDPOINTS = {
     STATUS: '/payment/status', // 결제 정보 검증 및 승인
     CHARGE: '/payment', // 충전
     RECOVERY: '/admin/zet-recovery', // 관리자 zet 복구
+    PAYMENT: '/admin/payments', // 관리자 payment 리스트 조회
+    PAYMENT_DETAIL: (paymentId: number) => `/admin/payments/${paymentId}`, // 관리자 payment 상세 조회
   },
 
   // FCM Token(1)

--- a/src/shared/ui/Modal/SpaceMailModal.tsx
+++ b/src/shared/ui/Modal/SpaceMailModal.tsx
@@ -18,7 +18,7 @@ export function SpaceMailModal({ isOpen, onOpenChange, name }: SpaceMailModalPro
 
   const handleConfirm = () => {
     onOpenChange(false);
-    router.push('/signal');
+    router.push('/signal?tab=letters');
   };
 
   return (


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #578 

### 🔎 작업 내용

- [x] admin payments API 연동
- [x] 전파거리 탭 URL 수정

### 📸 스크린샷 (선택)
<img width="1516" height="527" alt="image" src="https://github.com/user-attachments/assets/9794d396-3db9-479f-a722-2160a4fa8c53" />

<img width="476" height="901" alt="image" src="https://github.com/user-attachments/assets/21e1fa36-8ad6-4cc6-bbac-e722be42328f" />

### 📢 전달사항

<!-- 리뷰어 또는 팀에게 전달할 특이사항, 논의사항 등을 작성해주세요. -->

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 결제 내역 페이지가 더 이상 더미 데이터가 아닌 실제 백엔드 API와 연동되어 실시간 결제 로그 및 상세 정보를 제공합니다.

* **개선 사항**
  * 결제 로그 및 상세 정보의 필드명과 상태값이 변경되어 더 명확하게 표시됩니다.
  * 결제 로그 테이블의 컬럼 및 필터가 새로운 필드명과 상태값을 반영합니다.
  * 탭 전환 시 URL 쿼리 파라미터가 동기화되어, 새로고침/공유 시 현재 탭 상태가 유지됩니다.
  * SpaceMailModal에서 확인 시 `/signal?tab=letters`로 이동하도록 변경되었습니다.

* **버그 수정**
  * 데이터 새로고침 시 더미 데이터가 아닌 실제 데이터로 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->